### PR TITLE
fix(client+server): fix issues #46, #50, #51, #52, #47 + other bugfixes

### DIFF
--- a/packages/client/src/boot/i18n.ts
+++ b/packages/client/src/boot/i18n.ts
@@ -25,7 +25,7 @@ declare module "vue-i18n" {
 
 // This breaks SSR
 const i18n = createI18n<[MessageSchema], MessageLanguages, false>({
-  locale: "en-US",
+  locale: "it",
   fallbackLocale: "en-US",
   legacy: false,
   messages,

--- a/packages/client/src/components/book-copy-details-table.vue
+++ b/packages/client/src/components/book-copy-details-table.vue
@@ -25,7 +25,7 @@
       </q-th>
     </q-tr>
 
-    <q-tr v-for="bookCopy in bookCopies" :key="bookCopy.id">
+    <q-tr v-for="bookCopy in tableRows" :key="bookCopy.id">
       <q-td auto-width />
 
       <q-td
@@ -73,6 +73,7 @@ import { QTableColumn } from "quasar";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import BookCopyStatusChip from "src/components/book-copy-status-chip.vue";
+import { isAvailable } from "src/helpers/book-copy";
 import { getFieldValue } from "src/helpers/table-helpers";
 import { useBookCopyService } from "src/services/book-copy";
 import { BookCopyDetailsFragment } from "src/services/book-copy.graphql";
@@ -83,6 +84,7 @@ const { t } = useI18n();
 const props = defineProps<{
   bookCopyColumns: QTableColumn<BookCopyDetailsFragment>[];
   bookId: string;
+  showOnlyAvailable?: boolean | null;
 }>();
 
 const emit = defineEmits<{
@@ -108,6 +110,12 @@ const { useGetBookCopiesQuery } = useBookCopyService();
 const { bookCopies, loading } = useGetBookCopiesQuery(() => ({
   bookId: props.bookId,
 }));
+
+const tableRows = computed(() =>
+  props.showOnlyAvailable
+    ? bookCopies.value.filter((copy) => isAvailable(copy))
+    : bookCopies.value,
+);
 
 function getColspan(columnName: string) {
   return columnName === "original-code" || columnName === "status" ? 2 : 1;

--- a/packages/client/src/components/book-copy-details-table.vue
+++ b/packages/client/src/components/book-copy-details-table.vue
@@ -25,7 +25,7 @@
       </q-th>
     </q-tr>
 
-    <q-tr v-for="bookCopy in tableRows" :key="bookCopy.id">
+    <q-tr v-for="bookCopy in filteredBookCopies" :key="bookCopy.id">
       <q-td auto-width />
 
       <q-td
@@ -111,7 +111,7 @@ const { bookCopies, loading } = useGetBookCopiesQuery(() => ({
   bookId: props.bookId,
 }));
 
-const tableRows = computed(() =>
+const filteredBookCopies = computed(() =>
   props.showOnlyAvailable
     ? bookCopies.value.filter((copy) => isAvailable(copy))
     : bookCopies.value,

--- a/packages/client/src/components/edit-user-data-dialog.vue
+++ b/packages/client/src/components/edit-user-data-dialog.vue
@@ -118,8 +118,6 @@ const formData = computed<
     }
   >
 >(() => {
-  // eslint-disable-next-line no-console
-  console.log(user.value?.dateOfBirth);
   return {
     firstname: {
       label: t("auth.firstName"),

--- a/packages/client/src/components/header-bar.vue
+++ b/packages/client/src/components/header-bar.vue
@@ -47,6 +47,7 @@
         :label="t('routesNames.contacts')"
         :to="{ name: AvailableRouteNames.Contacts }"
       />
+      <language-dropdown-btn v-if="!isAuthenticated" />
     </k-toolbar>
   </q-header>
 </template>
@@ -65,6 +66,7 @@ import { useLateralDrawer } from "src/composables/use-lateral-drawer";
 import { AvailableRouteNames } from "src/models/routes";
 import { useAuthService } from "src/services/auth";
 import kToolbar from "./k-toolbar.vue";
+import LanguageDropdownBtn from "./language-dropdown-btn.vue";
 
 const { isDrawerOpen, showLateralDrawer } = useLateralDrawer();
 const { isHeaderSearchEnabled, searchText } = provideHeaderSearch();
@@ -75,7 +77,7 @@ const {
   selectedFilter,
 } = provideHeaderFilters();
 const { headerName } = provideHeaderName();
-const { user } = useAuthService();
+const { user, isAuthenticated } = useAuthService();
 const isLayoutHeaderXs = computed(() => Screen.lt.sm);
 provide(IsLayoutHeaderXsInjectionKey, isLayoutHeaderXs);
 const { t } = useI18n();

--- a/packages/client/src/components/language-dropdown-btn.vue
+++ b/packages/client/src/components/language-dropdown-btn.vue
@@ -5,7 +5,7 @@
         v-for="language in languages"
         :key="language.code"
         clickable
-        @click="locale = language.code"
+        @click="setLanguage(language.code)"
       >
         <q-item-section>
           <q-item-label>
@@ -20,6 +20,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
+import { setLanguage } from "src/boot/i18n";
 import { languages } from "src/models/language";
 const { locale } = useI18n();
 const selectedLanguageLabel = computed(

--- a/packages/client/src/components/language-dropdown-btn.vue
+++ b/packages/client/src/components/language-dropdown-btn.vue
@@ -1,0 +1,28 @@
+<template>
+  <q-btn-dropdown :label="selectedLanguageLabel" auto-close>
+    <q-list>
+      <q-item
+        v-for="language in languages"
+        :key="language.code"
+        clickable
+        @click="locale = language.code"
+      >
+        <q-item-section>
+          <q-item-label>
+            {{ language.label }}
+          </q-item-label>
+        </q-item-section>
+      </q-item>
+    </q-list>
+  </q-btn-dropdown>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import { languages } from "src/models/language";
+const { locale } = useI18n();
+const selectedLanguageLabel = computed(
+  () => languages.find(({ code }) => code === locale.value)?.label,
+);
+</script>

--- a/packages/client/src/components/manage-users/card-table-header.vue
+++ b/packages/client/src/components/manage-users/card-table-header.vue
@@ -1,6 +1,6 @@
 <template>
   <q-form
-    class="gap-16 items-center q-pt-md q-px-md row"
+    class="gap-16 items-center no-wrap q-pt-md q-px-md row"
     @submit="handleSubmit"
   >
     <q-input

--- a/packages/client/src/components/manage-users/cart-dialog.vue
+++ b/packages/client/src/components/manage-users/cart-dialog.vue
@@ -392,7 +392,7 @@ async function removeBook(book: BookSummaryFragment) {
       selectedBookCopies.value = currentlySelectedCopies;
     }
 
-    await Promise.all([refetchReservations(), refetchRequests()]);
+    await Promise.all([refetchReservations, refetchRequests]);
   } catch {
     notifyError(t("bookErrors.notCartBookDeleted"));
   }
@@ -423,7 +423,7 @@ function emptyAndDestroyCart() {
     } catch {
       notifyError(t("bookErrors.notCartDeleted"));
     } finally {
-      await Promise.all([refetchReservations(), refetchRequests()]);
+      await Promise.all([refetchReservations, refetchRequests]);
       onDialogHide();
     }
   });
@@ -458,8 +458,7 @@ function sellBooks() {
         input: {
           cartId: cartId.value,
           bookCopyIds: bookAndCopies.map(
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            ([_, selectedBookCopyId]) => selectedBookCopyId,
+            ([, selectedBookCopyId]) => selectedBookCopyId,
           ),
         },
       });
@@ -470,10 +469,11 @@ function sellBooks() {
         type: "positive",
         message: "Libri venduti con successo.",
       });
-
-      onDialogHide();
     } catch {
       notifyError(t("bookErrors.notSell"));
+    } finally {
+      await Promise.all([refetchRequests, refetchReservations]);
+      onDialogHide();
     }
   });
 }

--- a/packages/client/src/components/manage-users/cart-dialog.vue
+++ b/packages/client/src/components/manage-users/cart-dialog.vue
@@ -37,7 +37,6 @@
         :columns="columns"
         :loading="loading"
         :rows="cartBooks"
-        :rows-per-page-options="[0]"
         class="flex-delegate-height-management"
         row-key="id"
       >

--- a/packages/client/src/components/manage-users/cart-dialog.vue
+++ b/packages/client/src/components/manage-users/cart-dialog.vue
@@ -44,9 +44,9 @@
         <template #body="bodyProps">
           <q-tr>
             <q-td
-              v-for="{ name, value } in bodyProps.cols"
+              v-for="{ name, value, classes } in bodyProps.cols"
               :key="name"
-              auto-width
+              :class="classes"
             >
               <q-btn
                 v-if="name === 'selection'"
@@ -64,6 +64,9 @@
                 @click="removeBook(bodyProps.row)"
               />
               <span v-else>
+                <q-tooltip v-if="['subject', 'author'].includes(name)">
+                  {{ value }}
+                </q-tooltip>
                 {{ value }}
               </span>
             </q-td>
@@ -188,6 +191,7 @@ const columns = computed<QTableColumn<BookSummaryFragment>[]>(() => [
     field: "authorsFullName",
     label: t("book.fields.author"),
     align: "left",
+    classes: "max-width-160 ellipsis",
   },
   {
     name: "publisher",
@@ -200,12 +204,14 @@ const columns = computed<QTableColumn<BookSummaryFragment>[]>(() => [
     field: "subject",
     label: t("book.fields.subject"),
     align: "left",
+    classes: "max-width-160 ellipsis",
   },
   {
     name: "title",
     field: "title",
     label: t("book.fields.title"),
     align: "left",
+    classes: "text-wrap",
   },
   {
     name: "cover-price",

--- a/packages/client/src/components/manage-users/dialog-table.vue
+++ b/packages/client/src/components/manage-users/dialog-table.vue
@@ -5,10 +5,7 @@
     :columns="columns"
     :filter="searchQuery"
     :hide-pagination="hidePagination"
-    :pagination="{
-      ...pagination,
-      rowsPerPage: hidePagination ? 0 : pagination?.rowsPerPage,
-    }"
+    :pagination="pagination"
     :row-key="rowKey as string"
     :rows-per-page-options="rowsPerPageOptions"
     class="full-height"
@@ -54,7 +51,7 @@ const props = withDefaults(
     searchQuery: undefined,
     columns: undefined,
     rowKey: undefined,
-    rowsPerPageOptions: () => [5, 10, 20, 50, 100, 200],
+    rowsPerPageOptions: () => [0],
   },
 );
 

--- a/packages/client/src/components/manage-users/dialog-table.vue
+++ b/packages/client/src/components/manage-users/dialog-table.vue
@@ -5,7 +5,10 @@
     :columns="columns"
     :filter="searchQuery"
     :hide-pagination="hidePagination"
-    :pagination="pagination"
+    :pagination="{
+      ...pagination,
+      rowsPerPage: hidePagination ? 0 : pagination?.rowsPerPage,
+    }"
     :row-key="rowKey as string"
     :rows-per-page-options="rowsPerPageOptions"
     class="full-height"

--- a/packages/client/src/components/manage-users/edit-user-books-movements-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-books-movements-dialog.vue
@@ -13,11 +13,30 @@
         :rows="soldBookCopies as readonly SoldBookCopy[]"
         class="flex-delegate-height-management"
       >
+        <template #body-cell-author="{ value, col }">
+          <q-td :class="col.classes">
+            <q-tooltip>
+              {{ value }}
+            </q-tooltip>
+            {{ value }}
+          </q-td>
+        </template>
+
+        <template #body-cell-subject="{ value, col }">
+          <q-td :class="col.classes">
+            <q-tooltip>
+              {{ value }}
+            </q-tooltip>
+            {{ value }}
+          </q-td>
+        </template>
+
         <template #body-cell-problems="{ row }">
           <q-td class="text-center">
             <problems-button :book-copy="row" />
           </q-td>
         </template>
+
         <template #body-cell-history="{ row }">
           <q-td class="text-center">
             <q-btn
@@ -38,6 +57,24 @@
         :rows="purchasedBookCopies as readonly SoldBookCopy[]"
         class="flex-delegate-height-management"
       >
+        <template #body-cell-author="{ value, col }">
+          <q-td :class="col.classes">
+            <q-tooltip>
+              {{ value }}
+            </q-tooltip>
+            {{ value }}
+          </q-td>
+        </template>
+
+        <template #body-cell-subject="{ value, col }">
+          <q-td :class="col.classes">
+            <q-tooltip>
+              {{ value }}
+            </q-tooltip>
+            {{ value }}
+          </q-td>
+        </template>
+
         <template #body-cell-return="{ row }">
           <q-td class="text-center">
             <chip-button
@@ -133,18 +170,21 @@ const bookMiddleInfoColumns = computed<QTableColumn<SoldBookCopy>[]>(() => [
     field: ({ book }) => book.authorsFullName,
     name: "author",
     align: "left",
+    classes: "max-width-160 ellipsis",
   },
   {
     label: t("book.fields.subject"),
     field: ({ book }) => book.subject,
     name: "subject",
     align: "left",
+    classes: "max-width-160 ellipsis",
   },
   {
     label: t("book.fields.title"),
     field: ({ book }) => book.title,
     name: "title",
     align: "left",
+    classes: "text-wrap",
   },
   {
     label: t("book.fields.publisher"),
@@ -172,7 +212,7 @@ const soldColumns = computed<QTableColumn<SoldBookCopy>[]>(() => [
     field: "originalCode",
     name: "original-code",
     align: "left",
-    format: (val: string) => (val === "" ? "/" : val),
+    format: (val?: string) => val ?? "/",
   },
   ...bookMiddleInfoColumns.value,
   // TODO: not in the mockups, but should we add the date? (as an alternative to opening the history)

--- a/packages/client/src/components/manage-users/edit-user-books-movements-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-books-movements-dialog.vue
@@ -14,21 +14,11 @@
         class="flex-delegate-height-management"
       >
         <template #body-cell-author="{ value, col }">
-          <q-td :class="col.classes">
-            <q-tooltip>
-              {{ value }}
-            </q-tooltip>
-            {{ value }}
-          </q-td>
+          <table-cell-with-tooltip :class="col.classes" :value="value" />
         </template>
 
         <template #body-cell-subject="{ value, col }">
-          <q-td :class="col.classes">
-            <q-tooltip>
-              {{ value }}
-            </q-tooltip>
-            {{ value }}
-          </q-td>
+          <table-cell-with-tooltip :class="col.classes" :value="value" />
         </template>
 
         <template #body-cell-problems="{ row }">
@@ -58,21 +48,11 @@
         class="flex-delegate-height-management"
       >
         <template #body-cell-author="{ value, col }">
-          <q-td :class="col.classes">
-            <q-tooltip>
-              {{ value }}
-            </q-tooltip>
-            {{ value }}
-          </q-td>
+          <table-cell-with-tooltip :class="col.classes" :value="value" />
         </template>
 
         <template #body-cell-subject="{ value, col }">
-          <q-td :class="col.classes">
-            <q-tooltip>
-              {{ value }}
-            </q-tooltip>
-            {{ value }}
-          </q-td>
+          <table-cell-with-tooltip :class="col.classes" :value="value" />
         </template>
 
         <template #body-cell-return="{ row }">
@@ -114,6 +94,7 @@ import ChipButton from "./chip-button.vue";
 import DialogTable from "./dialog-table.vue";
 import ProblemsHistoryDialog from "./problems-history-dialog.vue";
 import ReturnBookDialog from "./return-book-dialog.vue";
+import tableCellWithTooltip from "./table-cell-with-tooltip.vue";
 
 // sold and purchased means the same thing, it's just a different perspective depending on which side the user is
 type SoldBookCopy = BookCopyDetailsFragment & {

--- a/packages/client/src/components/manage-users/edit-user-books-movements-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-books-movements-dialog.vue
@@ -94,7 +94,7 @@ import ChipButton from "./chip-button.vue";
 import DialogTable from "./dialog-table.vue";
 import ProblemsHistoryDialog from "./problems-history-dialog.vue";
 import ReturnBookDialog from "./return-book-dialog.vue";
-import tableCellWithTooltip from "./table-cell-with-tooltip.vue";
+import TableCellWithTooltip from "./table-cell-with-tooltip.vue";
 
 // sold and purchased means the same thing, it's just a different perspective depending on which side the user is
 type SoldBookCopy = BookCopyDetailsFragment & {

--- a/packages/client/src/components/manage-users/edit-user-stockdata-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-stockdata-dialog.vue
@@ -115,7 +115,6 @@
             :rows="copiesInStock.filter(({ donatedAt }) => donatedAt === null)"
             :columns="copiesInStockColumns"
             :loading="inStockLoading"
-            :rows-per-page-options="[0]"
             class="col"
           >
             <template #body-cell-author="{ value, col }">
@@ -355,12 +354,6 @@ const copiesInStockColumns = computed<QTableColumn<BookCopyDetailsFragment>[]>(
 );
 
 async function addBookToBeRegistered(bookISBN: string) {
-  if (
-    booksToRegister.value.map(({ isbnCode }) => isbnCode).includes(bookISBN)
-  ) {
-    notifyError(t("manageUsers.inStockDialog.errors.tooManyCopies"));
-    return;
-  }
   const book = await fetchBookByISBN(bookISBN);
   if (!book) {
     notifyError(t("manageUsers.inStockDialog.errors.noBook", [bookISBN]));

--- a/packages/client/src/components/manage-users/edit-user-stockdata-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-stockdata-dialog.vue
@@ -160,7 +160,7 @@ import { Dialog, QTableColumn, useDialogPluginComponent } from "quasar";
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { evictQuery } from "src/apollo/cache";
-import { isAvailable } from "src/helpers/book-copy";
+import { discountedPrice, isAvailable } from "src/helpers/book-copy";
 import { notifyError } from "src/helpers/error-messages";
 import { fetchBookByISBN } from "src/services/book";
 import {
@@ -251,7 +251,7 @@ function getCommonColumns<
       name: "price",
       headerClasses: "text-center",
       align: "left",
-      format: (val: number) => `${val.toFixed(2)} €`,
+      format: (val: number) => discountedPrice(val, "sell"),
     },
     {
       label: t("book.fields.utility"),
@@ -324,6 +324,7 @@ const copiesInStockColumns = computed<QTableColumn<BookCopyDetailsFragment>[]>(
       field: "originalCode",
       name: "original-code",
       align: "left",
+      format: (code?: string) => code ?? "/",
     },
     {
       label: t("book.fields.author"),

--- a/packages/client/src/components/manage-users/edit-user-stockdata-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-stockdata-dialog.vue
@@ -55,21 +55,11 @@
             class="col"
           >
             <template #body-cell-author="{ value, col }">
-              <q-td :class="col.classes">
-                <q-tooltip>
-                  {{ value }}
-                </q-tooltip>
-                {{ value }}
-              </q-td>
+              <table-cell-with-tooltip :class="col.classes" :value="value" />
             </template>
 
             <template #body-cell-subject="{ value, col }">
-              <q-td :class="col.classes">
-                <q-tooltip>
-                  {{ value }}
-                </q-tooltip>
-                {{ value }}
-              </q-td>
+              <table-cell-with-tooltip :class="col.classes" :value="value" />
             </template>
 
             <template #body-cell-status="{ value }">
@@ -118,21 +108,11 @@
             class="col"
           >
             <template #body-cell-author="{ value, col }">
-              <q-td :class="col.classes">
-                <q-tooltip>
-                  {{ value }}
-                </q-tooltip>
-                {{ value }}
-              </q-td>
+              <table-cell-with-tooltip :class="col.classes" :value="value" />
             </template>
 
             <template #body-cell-subject="{ value, col }">
-              <q-td :class="col.classes">
-                <q-tooltip>
-                  {{ value }}
-                </q-tooltip>
-                {{ value }}
-              </q-td>
+              <table-cell-with-tooltip :class="col.classes" :value="value" />
             </template>
 
             <template #body-cell-status="{ value }">
@@ -183,6 +163,7 @@ import ChipButton from "./chip-button.vue";
 import DialogTable from "./dialog-table.vue";
 import RetrieveAllBooksDialog from "./retrieve-all-books-dialog.vue";
 import StatusChip from "./status-chip.vue";
+import TableCellWithTooltip from "./table-cell-with-tooltip.vue";
 
 const props = defineProps<{
   userData: CustomerFragment;

--- a/packages/client/src/components/manage-users/edit-user-stockdata-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-stockdata-dialog.vue
@@ -54,6 +54,24 @@
             :loading="loading"
             class="col"
           >
+            <template #body-cell-author="{ value, col }">
+              <q-td :class="col.classes">
+                <q-tooltip>
+                  {{ value }}
+                </q-tooltip>
+                {{ value }}
+              </q-td>
+            </template>
+
+            <template #body-cell-subject="{ value, col }">
+              <q-td :class="col.classes">
+                <q-tooltip>
+                  {{ value }}
+                </q-tooltip>
+                {{ value }}
+              </q-td>
+            </template>
+
             <template #body-cell-status="{ value }">
               <q-td>
                 <status-chip :value="value" />
@@ -100,6 +118,24 @@
             :rows-per-page-options="[0]"
             class="col"
           >
+            <template #body-cell-author="{ value, col }">
+              <q-td :class="col.classes">
+                <q-tooltip>
+                  {{ value }}
+                </q-tooltip>
+                {{ value }}
+              </q-td>
+            </template>
+
+            <template #body-cell-subject="{ value, col }">
+              <q-td :class="col.classes">
+                <q-tooltip>
+                  {{ value }}
+                </q-tooltip>
+                {{ value }}
+              </q-td>
+            </template>
+
             <template #body-cell-status="{ value }">
               <q-td>
                 <status-chip :value="value" />
@@ -201,6 +237,7 @@ function getCommonColumns<
       name: "title",
       align: "left",
       format: (val: string) => startCase(toLower(val)),
+      classes: "text-wrap",
     },
     {
       label: t("book.fields.publisher"),
@@ -241,6 +278,7 @@ const booksToRegisterColumns = computed<QTableColumn<BookSummaryFragment>[]>(
       name: "author",
       align: "left",
       format: (val: string) => startCase(toLower(val)),
+      classes: "max-width-160 ellipsis",
     },
     {
       label: t("book.fields.subject"),
@@ -248,6 +286,7 @@ const booksToRegisterColumns = computed<QTableColumn<BookSummaryFragment>[]>(
       name: "subject",
       align: "left",
       format: (val: string) => startCase(toLower(val)),
+      classes: "max-width-160 ellipsis",
     },
     {
       label: t("book.fields.status"),
@@ -293,6 +332,7 @@ const copiesInStockColumns = computed<QTableColumn<BookCopyDetailsFragment>[]>(
       name: "author",
       align: "left",
       format: (val: string) => startCase(toLower(val)),
+      classes: "max-width-160 ellipsis",
     },
     {
       label: t("book.fields.subject"),
@@ -300,12 +340,14 @@ const copiesInStockColumns = computed<QTableColumn<BookCopyDetailsFragment>[]>(
       name: "subject",
       align: "left",
       format: (val: string) => startCase(toLower(val)),
+      classes: "max-width-160 ellipsis",
     },
     {
       label: t("book.fields.status"),
       field: isAvailable,
       name: "status",
       align: "left",
+      classes: "max-width-160 ellipsis",
     },
 
     ...getCommonColumns("copy"),

--- a/packages/client/src/components/manage-users/edit-user-stockdata-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-stockdata-dialog.vue
@@ -2,6 +2,7 @@
   <q-dialog
     ref="dialogRef"
     :persistent="tab === 'in-retrieval' && booksToRegister.length > 0"
+    full-width
     @hide="onDialogHide"
   >
     <k-dialog-card

--- a/packages/client/src/components/manage-users/pay-off-user-dialog.vue
+++ b/packages/client/src/components/manage-users/pay-off-user-dialog.vue
@@ -396,11 +396,7 @@ const getSettledOrToSettleCopiesPriceSum = (
   settled: boolean,
 ) =>
   (settled ? settledAt : !settledAt)
-    ? (book.originalPrice *
-        (props.user.discount
-          ? selectedLocation.value.buyRate
-          : selectedLocation.value.sellRate)) /
-      100
+    ? (book.originalPrice * selectedLocation.value.buyRate) / 100
     : 0;
 
 const totalCheckoutMoney = computed(() =>

--- a/packages/client/src/components/manage-users/pay-off-user-dialog.vue
+++ b/packages/client/src/components/manage-users/pay-off-user-dialog.vue
@@ -69,7 +69,8 @@
             >
               <q-td auto-width>
                 <q-checkbox
-                  v-if="row.id === Titles.InStock && selectableRows.length > 0"
+                  v-if="row.id === Titles.InStock"
+                  :disable="selectableRows.length === 0"
                   :model-value="rowsSelectionStatus"
                   dense
                   @update:model-value="swapAllRows()"
@@ -133,7 +134,7 @@
             </q-tr>
 
             <q-tr v-else>
-              <q-td v-for="col in cols" :key="col.name">
+              <q-td v-for="col in cols" :key="col.name" :class="col.classes">
                 <!--
                   Since we can't use #body-cell-[column-name] because we're using
                   the #body slot, we have to use v-if on the col.name instead
@@ -202,6 +203,9 @@
                   </q-menu>
                 </q-btn>
                 <span v-else>
+                  <q-tooltip v-if="['subject', 'author'].includes(col.name)">
+                    {{ col.value }}
+                  </q-tooltip>
                   {{ col.value }}
                 </span>
               </q-td>
@@ -313,6 +317,7 @@ const columns = computed<QTableColumn<BookCopyDetailsFragment>[]>(() => [
     field: ({ book }) => book.authorsFullName,
     label: t("book.fields.author"),
     align: "left",
+    classes: "max-width-160 ellipsis",
   },
   {
     name: "publisher",
@@ -325,12 +330,14 @@ const columns = computed<QTableColumn<BookCopyDetailsFragment>[]>(() => [
     field: ({ book }) => book.subject,
     label: t("book.fields.subject"),
     align: "left",
+    classes: "max-width-160 ellipsis",
   },
   {
     name: "title",
     field: ({ book }) => book.title,
     label: t("book.fields.title"),
     align: "left",
+    classes: "text-wrap",
   },
   {
     name: "cover-price",

--- a/packages/client/src/components/manage-users/pay-off-user-dialog.vue
+++ b/packages/client/src/components/manage-users/pay-off-user-dialog.vue
@@ -696,8 +696,10 @@ function returnAllBooks(remainingType: SettleRemainingType) {
       });
     } catch {
       notifyError(t("common.genericErrorMessage"));
+    } finally {
+      await Promise.all([refetchBookCopiesByOwner, refetchReturnedBookCopes]);
+      onDialogOK();
     }
-    onDialogOK();
   });
 }
 </script>

--- a/packages/client/src/components/manage-users/pay-off-user-dialog.vue
+++ b/packages/client/src/components/manage-users/pay-off-user-dialog.vue
@@ -43,8 +43,6 @@
             // We handle the group header in the #body slot, so it's safe to use a type that is different than the columns definition
             tableRows as readonly BookCopyDetailsFragment[]
           "
-          :rows-per-page-options="[0]"
-          hide-bottom
         >
           <template #header-cell-buy-price>
             <table-header-with-info

--- a/packages/client/src/components/manage-users/pay-off-user-dialog.vue
+++ b/packages/client/src/components/manage-users/pay-off-user-dialog.vue
@@ -409,7 +409,7 @@ const totalCheckoutMoney = computed(() =>
   ),
 );
 const totalCheckedOutMoney = computed(() =>
-  sumBy(ownedCopies.value, ({ settledAt, book }) =>
+  sumBy(returnedCopies.value, ({ settledAt, book }) =>
     getSettledOrToSettleCopiesPriceSum(settledAt, book, true),
   ),
 );

--- a/packages/client/src/components/manage-users/receipts-table.vue
+++ b/packages/client/src/components/manage-users/receipts-table.vue
@@ -2,7 +2,6 @@
   <q-table
     :columns="columns"
     :rows="receipts"
-    :rows-per-page-options="[0]"
     :hide-bottom="receipts.length > 0"
     :no-data-label="noDataLabel"
     square

--- a/packages/client/src/components/manage-users/requested-reserved-table.vue
+++ b/packages/client/src/components/manage-users/requested-reserved-table.vue
@@ -55,7 +55,7 @@ import { startCase, toLower } from "lodash-es";
 import { QTableColumn, QTableProps } from "quasar";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
-import { formatPrice } from "src/composables/use-misc-formats";
+import { discountedPrice } from "src/helpers/book-copy";
 import { RequestSummaryFragment } from "src/services/request.graphql";
 import { ReservationSummaryFragment } from "src/services/reservation.graphql";
 import UtilityChip from "../utility-chip.vue";
@@ -123,7 +123,7 @@ const columns = computed<
     field: ({ book: { originalPrice } }) => originalPrice,
     label: t("book.fields.price"),
     align: "left",
-    format: (val: string) => formatPrice(val),
+    format: (val: number) => discountedPrice(val, "sell"),
   },
   {
     name: "utility",

--- a/packages/client/src/components/manage-users/requested-reserved-table.vue
+++ b/packages/client/src/components/manage-users/requested-reserved-table.vue
@@ -1,5 +1,23 @@
 <template>
   <dialog-table :rows="rows" :columns="columns">
+    <template #body-cell-author="{ value, col }">
+      <q-td :class="col.classes">
+        <q-tooltip>
+          {{ value }}
+        </q-tooltip>
+        {{ value }}
+      </q-td>
+    </template>
+
+    <template #body-cell-subject="{ value, col }">
+      <q-td :class="col.classes">
+        <q-tooltip>
+          {{ value }}
+        </q-tooltip>
+        {{ value }}
+      </q-td>
+    </template>
+
     <template #body-cell-request-status="{ value }">
       <q-td>
         <span :class="value && !isShowingReservations ? 'text-positive' : ''">
@@ -75,6 +93,7 @@ const columns = computed<
     label: t("book.fields.author"),
     align: "left",
     format: (val: string) => startCase(toLower(val)),
+    classes: "max-width-160 ellipsis",
   },
   {
     name: "subject",
@@ -82,6 +101,7 @@ const columns = computed<
     label: t("book.fields.subject"),
     align: "left",
     format: (val: string) => startCase(toLower(val)),
+    classes: "max-width-160 ellipsis",
   },
   {
     name: "title",
@@ -89,6 +109,7 @@ const columns = computed<
     label: t("book.fields.title"),
     align: "left",
     format: (val: string) => startCase(toLower(val)),
+    classes: "text-wrap",
   },
   {
     name: "publisher",

--- a/packages/client/src/components/manage-users/requested-reserved-table.vue
+++ b/packages/client/src/components/manage-users/requested-reserved-table.vue
@@ -1,21 +1,11 @@
 <template>
   <dialog-table :rows="rows" :columns="columns">
     <template #body-cell-author="{ value, col }">
-      <q-td :class="col.classes">
-        <q-tooltip>
-          {{ value }}
-        </q-tooltip>
-        {{ value }}
-      </q-td>
+      <table-cell-with-tooltip :class="col.classes" :value="value" />
     </template>
 
     <template #body-cell-subject="{ value, col }">
-      <q-td :class="col.classes">
-        <q-tooltip>
-          {{ value }}
-        </q-tooltip>
-        {{ value }}
-      </q-td>
+      <table-cell-with-tooltip :class="col.classes" :value="value" />
     </template>
 
     <template #body-cell-request-status="{ value }">
@@ -60,6 +50,7 @@ import { RequestSummaryFragment } from "src/services/request.graphql";
 import { ReservationSummaryFragment } from "src/services/reservation.graphql";
 import UtilityChip from "../utility-chip.vue";
 import DialogTable from "./dialog-table.vue";
+import TableCellWithTooltip from "./table-cell-with-tooltip.vue";
 const { t } = useI18n();
 
 defineProps<

--- a/packages/client/src/components/manage-users/return-book-dialog.vue
+++ b/packages/client/src/components/manage-users/return-book-dialog.vue
@@ -49,7 +49,7 @@
           </template>
         </q-checkbox>
         <q-input
-          :model-value="discount"
+          :model-value="moneyToReimburse"
           :label="$t('manageUsers.moneyToGive')"
           outlined
           readonly
@@ -65,10 +65,11 @@ import { mdiInformationOutline } from "@quasar/extras/mdi-v7";
 import { useDialogPluginComponent } from "quasar";
 import { computed } from "vue";
 import { BookCopyDetailsFragment } from "src/services/book-copy.graphql";
+import { useRetailLocationService } from "src/services/retail-location";
 import { UserFragment } from "src/services/user.graphql";
 import KDialogFormCard from "../k-dialog-form-card.vue";
 
-defineProps<{
+const { user, bookCopy } = defineProps<{
   bookCopy: BookCopyDetailsFragment;
   user: UserFragment;
 }>();
@@ -78,9 +79,11 @@ defineEmits(useDialogPluginComponent.emitsObject);
 const { dialogRef, onDialogCancel, onDialogHide, onDialogOK } =
   useDialogPluginComponent<string>();
 
-const discount = computed(
-  () =>
-    // FIXME: add actual calculation of the discount
-    "10,00",
+const { selectedLocation } = useRetailLocationService();
+
+const moneyToReimburse = computed(() =>
+  user.discount
+    ? (bookCopy.book.originalPrice * selectedLocation.value.buyRate) / 100
+    : (bookCopy.book.originalPrice * selectedLocation.value.sellRate) / 100,
 );
 </script>

--- a/packages/client/src/components/manage-users/return-books-confirm-dialog.vue
+++ b/packages/client/src/components/manage-users/return-books-confirm-dialog.vue
@@ -68,7 +68,7 @@ import { useI18n } from "vue-i18n";
 import { BookCopyDetailsFragment } from "src/services/book-copy.graphql";
 import KDialogCard from "../k-dialog-card.vue";
 import DialogTable from "./dialog-table.vue";
-import tableCellWithTooltip from "./table-cell-with-tooltip.vue";
+import TableCellWithTooltip from "./table-cell-with-tooltip.vue";
 
 defineProps<{
   booksToReturn: BookCopyDetailsFragment[];

--- a/packages/client/src/components/manage-users/return-books-confirm-dialog.vue
+++ b/packages/client/src/components/manage-users/return-books-confirm-dialog.vue
@@ -36,12 +36,33 @@
       <span class="bg-grey-1 height-48 q-pa-md text-size-13 text-weight-medium">
         {{ tableTitle }}
       </span>
+
       <q-separator />
+
       <dialog-table
         :columns="columns"
         :rows="booksToReturn"
         class="flex-delegate-height-management"
       />
+
+      <template #body-cell-author="{ value, col }">
+        <q-td :class="col.classes">
+          <q-tooltip>
+            {{ value }}
+          </q-tooltip>
+          {{ value }}
+        </q-td>
+      </template>
+
+      <template #body-cell-subject="{ value, col }">
+        <q-td :class="col.classes">
+          <q-tooltip>
+            {{ value }}
+          </q-tooltip>
+          {{ value }}
+        </q-td>
+      </template>
+
       <template #card-actions>
         <q-btn :label="$t('common.cancel')" flat @click="onDialogCancel()" />
         <q-btn :label="saveLabel" color="positive" @click="onDialogOK()" />
@@ -94,6 +115,7 @@ const columns = computed<QTableColumn<BookCopyDetailsFragment>[]>(() => [
     field: ({ book }) => book.authorsFullName,
     label: t("book.fields.author"),
     align: "left",
+    classes: "max-width-160 ellipsis",
   },
   {
     name: "publisher",
@@ -106,12 +128,14 @@ const columns = computed<QTableColumn<BookCopyDetailsFragment>[]>(() => [
     field: ({ book }) => book.subject,
     label: t("book.fields.subject"),
     align: "left",
+    classes: "max-width-160 ellipsis",
   },
   {
     name: "title",
     field: ({ book }) => book.title,
     label: t("book.fields.title"),
     align: "left",
+    classes: "text-wrap",
   },
 ]);
 </script>

--- a/packages/client/src/components/manage-users/return-books-confirm-dialog.vue
+++ b/packages/client/src/components/manage-users/return-books-confirm-dialog.vue
@@ -37,11 +37,7 @@
         {{ tableTitle }}
       </span>
       <q-separator />
-      <dialog-table
-        :columns="columns"
-        :rows="booksToReturn"
-        :rows-per-page-options="[0]"
-      />
+      <dialog-table :columns="columns" :rows="booksToReturn" />
       <template #card-actions>
         <q-btn :label="$t('common.cancel')" flat @click="onDialogCancel()" />
         <q-btn :label="saveLabel" color="positive" @click="onDialogOK()" />

--- a/packages/client/src/components/manage-users/return-books-confirm-dialog.vue
+++ b/packages/client/src/components/manage-users/return-books-confirm-dialog.vue
@@ -45,21 +45,11 @@
         class="flex-delegate-height-management"
       >
         <template #body-cell-author="{ value, col }">
-          <q-td :class="col.classes">
-            <q-tooltip>
-              {{ value }}
-            </q-tooltip>
-            {{ value }}
-          </q-td>
+          <table-cell-with-tooltip :class="col.classes" :value="value" />
         </template>
 
         <template #body-cell-subject="{ value, col }">
-          <q-td :class="col.classes">
-            <q-tooltip>
-              {{ value }}
-            </q-tooltip>
-            {{ value }}
-          </q-td>
+          <table-cell-with-tooltip :class="col.classes" :value="value" />
         </template>
       </dialog-table>
 
@@ -78,6 +68,7 @@ import { useI18n } from "vue-i18n";
 import { BookCopyDetailsFragment } from "src/services/book-copy.graphql";
 import KDialogCard from "../k-dialog-card.vue";
 import DialogTable from "./dialog-table.vue";
+import tableCellWithTooltip from "./table-cell-with-tooltip.vue";
 
 defineProps<{
   booksToReturn: BookCopyDetailsFragment[];

--- a/packages/client/src/components/manage-users/return-books-confirm-dialog.vue
+++ b/packages/client/src/components/manage-users/return-books-confirm-dialog.vue
@@ -43,25 +43,25 @@
         :columns="columns"
         :rows="booksToReturn"
         class="flex-delegate-height-management"
-      />
-
-      <template #body-cell-author="{ value, col }">
-        <q-td :class="col.classes">
-          <q-tooltip>
+      >
+        <template #body-cell-author="{ value, col }">
+          <q-td :class="col.classes">
+            <q-tooltip>
+              {{ value }}
+            </q-tooltip>
             {{ value }}
-          </q-tooltip>
-          {{ value }}
-        </q-td>
-      </template>
+          </q-td>
+        </template>
 
-      <template #body-cell-subject="{ value, col }">
-        <q-td :class="col.classes">
-          <q-tooltip>
+        <template #body-cell-subject="{ value, col }">
+          <q-td :class="col.classes">
+            <q-tooltip>
+              {{ value }}
+            </q-tooltip>
             {{ value }}
-          </q-tooltip>
-          {{ value }}
-        </q-td>
-      </template>
+          </q-td>
+        </template>
+      </dialog-table>
 
       <template #card-actions>
         <q-btn :label="$t('common.cancel')" flat @click="onDialogCancel()" />

--- a/packages/client/src/components/manage-users/return-books-confirm-dialog.vue
+++ b/packages/client/src/components/manage-users/return-books-confirm-dialog.vue
@@ -37,7 +37,11 @@
         {{ tableTitle }}
       </span>
       <q-separator />
-      <dialog-table :columns="columns" :rows="booksToReturn" />
+      <dialog-table
+        :columns="columns"
+        :rows="booksToReturn"
+        class="flex-delegate-height-management"
+      />
       <template #card-actions>
         <q-btn :label="$t('common.cancel')" flat @click="onDialogCancel()" />
         <q-btn :label="saveLabel" color="positive" @click="onDialogOK()" />
@@ -48,7 +52,7 @@
 
 <script setup lang="ts">
 import { QTableColumn, useDialogPluginComponent } from "quasar";
-import { computed, ref } from "vue";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { BookCopyDetailsFragment } from "src/services/book-copy.graphql";
 import KDialogCard from "../k-dialog-card.vue";
@@ -61,6 +65,8 @@ defineProps<{
   tableTitle: string;
   title: string;
   booksSoldToOthers: number;
+  totalCheckoutMoney: number;
+  totalCheckedOutMoney: number;
 }>();
 
 defineEmits(useDialogPluginComponent.emitsObject);
@@ -69,9 +75,6 @@ const { dialogRef, onDialogCancel, onDialogHide, onDialogOK } =
   useDialogPluginComponent();
 
 const { t } = useI18n();
-
-const totalCheckoutMoney = ref(0);
-const totalCheckedOutMoney = ref(0);
 
 const columns = computed<QTableColumn<BookCopyDetailsFragment>[]>(() => [
   {

--- a/packages/client/src/components/manage-users/table-cell-with-tooltip.vue
+++ b/packages/client/src/components/manage-users/table-cell-with-tooltip.vue
@@ -1,0 +1,12 @@
+<template>
+  <q-td>
+    <q-tooltip>
+      {{ value }}
+    </q-tooltip>
+    {{ value }}
+  </q-td>
+</template>
+
+<script setup lang="ts">
+defineProps<{ value: string | number }>();
+</script>

--- a/packages/client/src/components/manage-users/table-cell-with-tooltip.vue
+++ b/packages/client/src/components/manage-users/table-cell-with-tooltip.vue
@@ -8,5 +8,5 @@
 </template>
 
 <script setup lang="ts">
-defineProps<{ value: string | number }>();
+defineProps<{ value: string }>();
 </script>

--- a/packages/client/src/components/reserve-books-by-class-dialog.vue
+++ b/packages/client/src/components/reserve-books-by-class-dialog.vue
@@ -39,6 +39,7 @@ import { QTableColumn, useDialogPluginComponent } from "quasar";
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { formatPrice } from "src/composables/use-misc-formats";
+import { discountedPrice } from "src/helpers/book-copy";
 import { BookSummaryFragment } from "src/services/book.graphql";
 import { BookWithAvailableCopiesFragment } from "src/services/cart.graphql";
 import KDialogCard from "./k-dialog-card.vue";
@@ -98,11 +99,10 @@ const columns = computed<QTableColumn<BookWithAvailableCopiesFragment>[]>(
     },
     {
       name: "price",
-      // TODO: add correct calculation
       field: ({ originalPrice }) => originalPrice,
       label: t("book.fields.price"),
       align: "left",
-      format: formatPrice,
+      format: (val: number) => discountedPrice(val, "sell"),
     },
     {
       name: "available-copies",

--- a/packages/client/src/components/settings-dialog.vue
+++ b/packages/client/src/components/settings-dialog.vue
@@ -4,31 +4,24 @@
       :title="t('sidebar.settings')"
       actions-padding
       size="fullscreen"
-      @submit="
-        onDialogOK({
-          type: 'save',
-          settings: newSettings,
-        })
-      "
+      @submit="validateSettings()"
     >
       <q-card-section
         class="column gap-4 no-wrap q-pb-xs q-pt-lg q-px-lg width-700"
       >
         <q-input
-          v-model.number="purchaseRate"
+          v-model.number="newSettings.buyRate"
           :label="t('general.settings.purchaseRate')"
           bottom-slots
           outlined
-          readonly
           suffix="%"
           type="number"
         />
         <q-input
-          v-model.number="saleRate"
+          v-model.number="newSettings.sellRate"
           :label="t('general.settings.saleRate')"
           bottom-slots
           outlined
-          readonly
           suffix="%"
           type="number"
         />
@@ -69,6 +62,7 @@
         <q-space />
 
         <q-btn :label="t('common.cancel')" flat @click="onDialogCancel()" />
+
         <q-btn
           :form="uniqueFormId"
           :label="t('common.save')"
@@ -90,9 +84,10 @@ import {
   allowOnlyIntegerNumbers,
   greaterThanZeroRule,
 } from "src/helpers/rules";
-import { Settings, SettingsUpdate, SettingsUpdateInput } from "src/models/book";
+import { SettingsUpdate } from "src/models/book";
+import { RetailLocationSettingsFragment } from "src/services/retail-location.graphql";
 
-const props = defineProps<Settings>();
+const props = defineProps<Omit<RetailLocationSettingsFragment, "__typename">>();
 
 defineEmits(useDialogPluginComponent.emitsObject);
 
@@ -101,14 +96,36 @@ const { dialogRef, onDialogCancel, onDialogOK, onDialogHide } =
 
 const { t } = useI18n();
 
-const newSettings = reactive<SettingsUpdateInput>({
+const newSettings = reactive<RetailLocationSettingsFragment>({
   maxBookingDays: props.maxBookingDays,
   payOffEnabled: props.payOffEnabled,
   warehouseMaxBlockSize: props.warehouseMaxBlockSize,
+  buyRate: props.buyRate,
+  sellRate: props.sellRate,
 });
 
-const purchaseRate = props.buyRate;
-const saleRate = props.sellRate;
+function validateSettings() {
+  const settingsUpdate = {
+    type: "save" as const,
+    settings: newSettings,
+  };
+
+  if (
+    newSettings.buyRate !== props.buyRate ||
+    newSettings.sellRate !== props.sellRate
+  ) {
+    Dialog.create({
+      title: t("general.settings.updateRatesConfirmTitle"),
+      message: t("general.settings.updateRatesConfirmMessage"),
+      ok: t("actions.continue"),
+      cancel: t("common.cancel"),
+    }).onOk(() => {
+      onDialogOK(settingsUpdate);
+    });
+  } else {
+    onDialogOK(settingsUpdate);
+  }
+}
 
 function confirmReset() {
   Dialog.create({

--- a/packages/client/src/components/settings-dialog.vue
+++ b/packages/client/src/components/settings-dialog.vue
@@ -117,7 +117,7 @@ function validateSettings() {
     Dialog.create({
       title: t("general.settings.updateRatesConfirmTitle"),
       message: t("general.settings.updateRatesConfirmMessage"),
-      ok: t("actions.continue"),
+      ok: t("actions.update"),
       cancel: t("common.cancel"),
     }).onOk(() => {
       onDialogOK(settingsUpdate);

--- a/packages/client/src/composables/use-table-filters.ts
+++ b/packages/client/src/composables/use-table-filters.ts
@@ -1,5 +1,6 @@
 import { QTableProps } from "quasar";
 import { computed, reactive } from "vue";
+import { BookCopyQueryFilter } from "src/@generated/graphql";
 import {
   FilterPath,
   useTranslatedFilters,
@@ -62,6 +63,21 @@ export function useTableFilters(
     };
   });
 
+  const booleanFilters = computed<
+    Omit<BookCopyQueryFilter, "search"> | undefined
+  >(() =>
+    tableFilter.filters.length === 0
+      ? undefined
+      : {
+          // tableFilter is the checkbox array model
+          isAvailable: tableFilter.filters.includes(
+            "isAvailable" satisfies keyof BookCopyQueryFilter,
+          )
+            ? true
+            : undefined,
+        },
+  );
+
   // This filter isn't actually used BUT by passing our filters to the QTable it allows
   // the component to throw the "@request" event which is used to refetch our data
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
@@ -72,5 +88,6 @@ export function useTableFilters(
     filterOptions,
     tableFilter,
     filterMethod,
+    booleanFilters,
   };
 }

--- a/packages/client/src/css/utilities.scss
+++ b/packages/client/src/css/utilities.scss
@@ -178,6 +178,10 @@ $heights-list: 0, 24, 48, 52, 400, 600;
   white-space: pre-wrap;
 }
 
+.text-wrap {
+  white-space: wrap !important;
+}
+
 .sticky {
   position: sticky;
 

--- a/packages/client/src/helpers/book-copy.ts
+++ b/packages/client/src/helpers/book-copy.ts
@@ -1,5 +1,9 @@
 import { ProblemType } from "src/@generated/graphql";
+import { formatPrice } from "src/composables/use-misc-formats";
 import { BookCopyDetailsFragment } from "src/services/book-copy.graphql";
+import { useRetailLocationService } from "src/services/retail-location";
+
+const { selectedLocation } = useRetailLocationService();
 
 export const hasProblem = ({ problems }: BookCopyDetailsFragment) =>
   problems?.some(({ resolvedAt }) => !resolvedAt);
@@ -41,3 +45,12 @@ export function getStatus(bookCopy: BookCopyDetailsFragment): BookCopyStatus {
             ? "reimbursed"
             : "available";
 }
+
+export const discountedPrice = (originalPrice: number, kind: "sell" | "buy") =>
+  formatPrice(
+    (originalPrice *
+      (kind === "buy"
+        ? selectedLocation.value.buyRate
+        : selectedLocation.value.sellRate)) /
+      100,
+  );

--- a/packages/client/src/i18n/en-US/actions.ts
+++ b/packages/client/src/i18n/en-US/actions.ts
@@ -17,4 +17,5 @@ export default {
   selectAtLeastOneOption: "Select at least one option",
   editName: "Edit Name",
   selectFeedbackType: "Select feedback type",
+  update: "Update",
 };

--- a/packages/client/src/i18n/en-US/book-errors.ts
+++ b/packages/client/src/i18n/en-US/book-errors.ts
@@ -32,5 +32,5 @@ export default {
   notDonated: "Could not donate the selected copy to the Mercatino.",
   notAllDonated: "Could not donate all the selected copies to the Mercatino.",
   notProblem: "Could not report the problem for the selected copy.",
-  notSolveProblem: "Could not solbe the problem for the selected copy.",
+  notSolveProblem: "Could not solve the problem for the selected copy.",
 };

--- a/packages/client/src/i18n/en-US/general.ts
+++ b/packages/client/src/i18n/en-US/general.ts
@@ -65,6 +65,9 @@ export default {
     maxBooksDimension:
       "Max dimension of the book stacks to allow for fragmentation",
     payOffEnabled: "Enable the possibility to perform payoffs",
+    updateRatesConfirmTitle: "Update the purchase/sale rate?",
+    updateRatesConfirmMessage:
+      "WARNING: you are updating the purchase and/or sale rate; make sure that this is ONLY done at the beginning or at the end of the Mercatino's activity period.",
     resetMessage:
       "You are performing the reset of all the system data to prepare the software for the following year's activities. Do you wish to proceed?",
     resetButton: "Perform annual reset",

--- a/packages/client/src/i18n/en-US/manage-users.ts
+++ b/packages/client/src/i18n/en-US/manage-users.ts
@@ -32,7 +32,7 @@ export default {
       "The number of titles currently available among those requested by the user",
   },
   payOff: "Pay off user",
-  payOffDisabled: "User pay-offs are currently disabled.",
+  payOffDisabled: "User payoffs are currently disabled.",
   filters: {
     withAvailable: "With Available",
     withRequested: "With Requested",

--- a/packages/client/src/i18n/en-US/manage-users.ts
+++ b/packages/client/src/i18n/en-US/manage-users.ts
@@ -55,7 +55,6 @@ export default {
     deleteBookBtnTooltip: "Delete permanently this copy from the database",
     errors: {
       noBook: "No book with the ISBN {0} was found",
-      tooManyCopies: "Cannot accept more than one copy of the same book",
       retrieval: "There was an error during the retrieval of the books",
     },
   },

--- a/packages/client/src/i18n/en-US/manage-users.ts
+++ b/packages/client/src/i18n/en-US/manage-users.ts
@@ -32,6 +32,7 @@ export default {
       "The number of titles currently available among those requested by the user",
   },
   payOff: "Pay off user",
+  payOffDisabled: "User pay-offs are currently disabled.",
   filters: {
     withAvailable: "With Available",
     withRequested: "With Requested",

--- a/packages/client/src/i18n/it/actions.ts
+++ b/packages/client/src/i18n/it/actions.ts
@@ -17,4 +17,5 @@ export default {
   selectAtLeastOneOption: "Seleziona almeno una opzione",
   editName: "Modifica Nome",
   selectFeedbackType: "Seleziona il tipo di feedback",
+  update: "Aggiorna",
 };

--- a/packages/client/src/i18n/it/general.ts
+++ b/packages/client/src/i18n/it/general.ts
@@ -65,6 +65,9 @@ export default {
     maxBooksDimension:
       "Dimensione max dei blocchi di libri da inserire per permettere la frammentazione",
     payOffEnabled: "Abilita la possibilità di effettuare liquidazioni",
+    updateRatesConfirmTitle: "Aggiornare l'aliquota di acquisto/vendita?",
+    updateRatesConfirmMessage:
+      "ATTENZIONE: stai aggiornando le aliquote di acquisto e/o vendita; assicurati che questo sia effettuato solamente all'inizio o alla fine del periodo di attività del Mercatino.",
     resetMessage:
       "Stai effettuando il reset di tutti i dati di sistema per predisporre il software alle attività dell'anno successivo. Vuoi procedere?",
     resetButton: "Effettua reset annuale",

--- a/packages/client/src/i18n/it/manage-users.ts
+++ b/packages/client/src/i18n/it/manage-users.ts
@@ -55,8 +55,6 @@ export default {
     deleteBookBtnTooltip: "Elimina definitivamente questa copia dal database",
     errors: {
       noBook: "Non è stato trovato nessun libro con ISBN {0}",
-      tooManyCopies:
-        "Non è possibile accettare più di una copia dello stesso libro",
       retrieval: "C'è stato un errore nel ritiro dei libri",
     },
   },

--- a/packages/client/src/i18n/it/manage-users.ts
+++ b/packages/client/src/i18n/it/manage-users.ts
@@ -32,6 +32,7 @@ export default {
       "Il numero di titoli attualmente disponibili tra quelli richiesti dall'utente",
   },
   payOff: "Liquida utente",
+  payOffDisabled: "Le liquidazioni al momento sono disabilitate.",
   filters: {
     withAvailable: "Con Disponibili",
     withRequested: "Con Richiesti",

--- a/packages/client/src/layouts/authenticated-layout.vue
+++ b/packages/client/src/layouts/authenticated-layout.vue
@@ -415,7 +415,6 @@ import { useAuthService, useLogoutMutation } from "src/services/auth";
 import { useRetailLocationService } from "src/services/retail-location";
 import {
   RetailLocationSettingsFragment,
-  RetailLocationSettingsFragmentDoc,
   useUpdateRetailLocationSettingsMutation,
 } from "src/services/retail-location.graphql";
 import {
@@ -483,21 +482,12 @@ function openSettings() {
   }).onOk(async (payload: SettingsUpdate) => {
     if (payload.type === "save") {
       try {
-        const { cache } = await updateRetailLocationSettings({
+        await updateRetailLocationSettings({
           input: {
             ...payload.settings,
             retailLocationId: selectedLocation.value.id,
           },
         });
-
-        cache.updateFragment(
-          {
-            fragment: RetailLocationSettingsFragmentDoc,
-            fragmentName: "RetailLocationSettings",
-            id: cache.identify(selectedLocation.value),
-          },
-          () => ({ ...payload.settings }),
-        );
       } catch {
         notifyError(t("common.genericErrorMessage"));
       }

--- a/packages/client/src/layouts/authenticated-layout.vue
+++ b/packages/client/src/layouts/authenticated-layout.vue
@@ -415,6 +415,7 @@ import { useAuthService, useLogoutMutation } from "src/services/auth";
 import { useRetailLocationService } from "src/services/retail-location";
 import {
   RetailLocationSettingsFragment,
+  RetailLocationSettingsFragmentDoc,
   useUpdateRetailLocationSettingsMutation,
 } from "src/services/retail-location.graphql";
 import {
@@ -482,12 +483,21 @@ function openSettings() {
   }).onOk(async (payload: SettingsUpdate) => {
     if (payload.type === "save") {
       try {
-        await updateRetailLocationSettings({
+        const { cache } = await updateRetailLocationSettings({
           input: {
             ...payload.settings,
             retailLocationId: selectedLocation.value.id,
           },
         });
+
+        cache.updateFragment(
+          {
+            fragment: RetailLocationSettingsFragmentDoc,
+            fragmentName: "RetailLocationSettings",
+            id: cache.identify(selectedLocation.value),
+          },
+          () => ({ ...payload.settings }),
+        );
       } catch {
         notifyError(t("common.genericErrorMessage"));
       }

--- a/packages/client/src/layouts/authenticated-layout.vue
+++ b/packages/client/src/layouts/authenticated-layout.vue
@@ -408,11 +408,14 @@ import {
 } from "src/composables/use-lateral-drawer";
 import { useTheme } from "src/composables/use-theme";
 import { notifyError } from "src/helpers/error-messages";
-import { Settings, SettingsUpdate } from "src/models/book";
+import { SettingsUpdate } from "src/models/book";
 import { AvailableRouteNames } from "src/models/routes";
 import { useAuthService, useLogoutMutation } from "src/services/auth";
 import { useRetailLocationService } from "src/services/retail-location";
-import { useUpdateRetailLocationSettingsMutation } from "src/services/retail-location.graphql";
+import {
+  RetailLocationSettingsFragment,
+  useUpdateRetailLocationSettingsMutation,
+} from "src/services/retail-location.graphql";
 import {
   UserFragmentDoc,
   useUpdateUserMutation,
@@ -490,7 +493,7 @@ function openSettings() {
       maxBookingDays: selectedLocation.value.maxBookingDays,
       sellRate: selectedLocation.value.sellRate,
       payOffEnabled: selectedLocation.value.payOffEnabled,
-    } satisfies Settings,
+    } satisfies RetailLocationSettingsFragment,
   }).onOk(async (payload: SettingsUpdate) => {
     if (payload.type === "save") {
       try {

--- a/packages/client/src/layouts/authenticated-layout.vue
+++ b/packages/client/src/layouts/authenticated-layout.vue
@@ -409,6 +409,7 @@ import {
 import { useTheme } from "src/composables/use-theme";
 import { notifyError } from "src/helpers/error-messages";
 import { SettingsUpdate } from "src/models/book";
+import { languages } from "src/models/language";
 import { AvailableRouteNames } from "src/models/routes";
 import { useAuthService, useLogoutMutation } from "src/services/auth";
 import { useRetailLocationService } from "src/services/retail-location";
@@ -433,23 +434,7 @@ const TOOLTIP_SHARED_PROPS: QTooltipProps = {
 
 const { t, locale } = useI18n();
 
-interface Language {
-  code: string;
-  label: string;
-}
-
 const { theme } = useTheme();
-
-const languages = [
-  {
-    code: "en-US" as const,
-    label: "English",
-  },
-  {
-    code: "it" as const,
-    label: "Italiano",
-  },
-] satisfies Language[];
 
 const isOnline = useOnline();
 watch(isOnline, (becomeOnline) => {

--- a/packages/client/src/models/book.ts
+++ b/packages/client/src/models/book.ts
@@ -1,8 +1,5 @@
-import {
-  BookQueryFilter,
-  UpdateRetailLocationSettingsInput,
-} from "src/@generated/graphql";
-import { RetailLocationFragment } from "src/services/retail-location.graphql";
+import { BookQueryFilter } from "src/@generated/graphql";
+import { RetailLocationSettingsFragment } from "src/services/retail-location.graphql";
 
 export const enum BookCopyStatuses {
   LOST = "lost",
@@ -49,17 +46,9 @@ export enum BooksTab {
   PURCHASED = "purchased",
 }
 
-export type SettingsUpdateInput = Omit<
-  UpdateRetailLocationSettingsInput,
-  "retailLocationId"
->;
-
-export type Settings = Pick<RetailLocationFragment, "buyRate" | "sellRate"> &
-  SettingsUpdateInput;
-
 export type SettingsUpdate =
   | {
       type: "save";
-      settings: SettingsUpdateInput;
+      settings: RetailLocationSettingsFragment;
     }
   | { type: "reset" };

--- a/packages/client/src/models/language.ts
+++ b/packages/client/src/models/language.ts
@@ -1,0 +1,15 @@
+interface Language {
+  code: string;
+  label: string;
+}
+
+export const languages = [
+  {
+    code: "en-US" as const,
+    label: "English",
+  },
+  {
+    code: "it" as const,
+    label: "Italiano",
+  },
+] satisfies Language[];

--- a/packages/client/src/pages/catalog.vue
+++ b/packages/client/src/pages/catalog.vue
@@ -63,7 +63,7 @@ import { BookCreateInput } from "src/@generated/graphql";
 import AddBookDialog from "src/components/add-book-dialog.vue";
 import HeaderSearchBarFilters from "src/components/header-search-bar-filters.vue";
 import StatusChip from "src/components/manage-users/status-chip.vue";
-import tableCellWithTooltip from "src/components/manage-users/table-cell-with-tooltip.vue";
+import TableCellWithTooltip from "src/components/manage-users/table-cell-with-tooltip.vue";
 import UtilityChip from "src/components/utility-chip.vue";
 import { useTableFilters } from "src/composables/use-table-filters";
 import { notifyError } from "src/helpers/error-messages";

--- a/packages/client/src/pages/catalog.vue
+++ b/packages/client/src/pages/catalog.vue
@@ -144,7 +144,7 @@ const columns = computed<QTableColumn<BookSummaryFragment>[]>(() => [
     label: t("book.fields.coverPrice"),
     field: "originalPrice",
     align: "left",
-    format: (val: string) => formatPrice(val),
+    format: formatPrice,
   },
   {
     name: "status",

--- a/packages/client/src/pages/catalog.vue
+++ b/packages/client/src/pages/catalog.vue
@@ -17,33 +17,48 @@
         </template>
       </header-search-bar-filters>
 
-      <q-card-section class="col no-wrap q-pa-none row">
-        <q-table
-          ref="tableRef"
-          v-model:pagination="pagination"
-          :columns="columns"
-          :filter="tableFilter"
-          :filter-method="filterMethod"
-          :loading="loading"
-          :rows-per-page-options="ROWS_PER_PAGE_OPTIONS"
-          :rows="tableRows"
-          square
-          class="col"
-          @request="onRequest"
-        >
-          <template #body-cell-status="{ value }">
-            <q-td>
-              <status-chip :value="value" />
-            </q-td>
-          </template>
+      <q-table
+        ref="tableRef"
+        v-model:pagination="pagination"
+        :columns="columns"
+        :filter="tableFilter"
+        :filter-method="filterMethod"
+        :loading="loading"
+        :rows-per-page-options="ROWS_PER_PAGE_OPTIONS"
+        :rows="tableRows"
+        class="col"
+        @request="onRequest"
+      >
+        <template #body-cell-author="{ value, col }">
+          <q-td :class="col.classes">
+            <q-tooltip>
+              {{ value }}
+            </q-tooltip>
+            {{ value }}
+          </q-td>
+        </template>
 
-          <template #body-cell-utility="{ value }">
-            <q-td>
-              <utility-chip :utility="value" />
-            </q-td>
-          </template>
-        </q-table>
-      </q-card-section>
+        <template #body-cell-subject="{ value, col }">
+          <q-td :class="col.classes">
+            <q-tooltip>
+              {{ value }}
+            </q-tooltip>
+            {{ value }}
+          </q-td>
+        </template>
+
+        <template #body-cell-status="{ value }">
+          <q-td>
+            <status-chip :value="value" />
+          </q-td>
+        </template>
+
+        <template #body-cell-utility="{ value }">
+          <q-td class="text-center">
+            <utility-chip :utility="value" />
+          </q-td>
+        </template>
+      </q-table>
     </q-card>
   </q-page>
 </template>
@@ -99,6 +114,7 @@ const columns = computed<QTableColumn<BookSummaryFragment>[]>(() => [
     field: "authorsFullName",
     align: "left",
     format: (val: string) => startCase(toLower(val)),
+    classes: "max-width-160 ellipsis",
   },
   {
     name: "publisher",
@@ -113,6 +129,7 @@ const columns = computed<QTableColumn<BookSummaryFragment>[]>(() => [
     field: "subject",
     align: "left",
     format: (val: string) => startCase(toLower(val)),
+    classes: "max-width-160 ellipsis",
   },
   {
     name: "title",
@@ -120,6 +137,7 @@ const columns = computed<QTableColumn<BookSummaryFragment>[]>(() => [
     field: "title",
     align: "left",
     format: (val: string) => startCase(toLower(val)),
+    classes: "text-wrap",
   },
   {
     name: "price",

--- a/packages/client/src/pages/catalog.vue
+++ b/packages/client/src/pages/catalog.vue
@@ -30,21 +30,11 @@
         @request="onRequest"
       >
         <template #body-cell-author="{ value, col }">
-          <q-td :class="col.classes">
-            <q-tooltip>
-              {{ value }}
-            </q-tooltip>
-            {{ value }}
-          </q-td>
+          <table-cell-with-tooltip :class="col.classes" :value="value" />
         </template>
 
         <template #body-cell-subject="{ value, col }">
-          <q-td :class="col.classes">
-            <q-tooltip>
-              {{ value }}
-            </q-tooltip>
-            {{ value }}
-          </q-td>
+          <table-cell-with-tooltip :class="col.classes" :value="value" />
         </template>
 
         <template #body-cell-status="{ value }">
@@ -82,6 +72,8 @@ import {
   useCreateNewBookMutation,
 } from "src/services/book.graphql";
 import { formatPrice } from "../composables/use-misc-formats";
+import tableCellWithTooltip from "./table-cell-with-tooltip.vue";
+
 const { t } = useI18n();
 
 const tableRef = ref<QTable>();

--- a/packages/client/src/pages/catalog.vue
+++ b/packages/client/src/pages/catalog.vue
@@ -63,6 +63,7 @@ import { BookCreateInput } from "src/@generated/graphql";
 import AddBookDialog from "src/components/add-book-dialog.vue";
 import HeaderSearchBarFilters from "src/components/header-search-bar-filters.vue";
 import StatusChip from "src/components/manage-users/status-chip.vue";
+import tableCellWithTooltip from "src/components/manage-users/table-cell-with-tooltip.vue";
 import UtilityChip from "src/components/utility-chip.vue";
 import { useTableFilters } from "src/composables/use-table-filters";
 import { notifyError } from "src/helpers/error-messages";
@@ -72,7 +73,6 @@ import {
   useCreateNewBookMutation,
 } from "src/services/book.graphql";
 import { formatPrice } from "../composables/use-misc-formats";
-import tableCellWithTooltip from "./table-cell-with-tooltip.vue";
 
 const { t } = useI18n();
 

--- a/packages/client/src/pages/manage-users.vue
+++ b/packages/client/src/pages/manage-users.vue
@@ -181,9 +181,14 @@
             <q-td>
               <chip-button
                 color="primary"
+                :disabled="!selectedLocation.payOffEnabled"
                 :label="$t('manageUsers.payOff')"
                 @click="openPayOff(row)"
-              />
+              >
+                <q-tooltip v-if="!selectedLocation.payOffEnabled">
+                  {{ t("manageUsers.payOffDisabled") }}
+                </q-tooltip>
+              </chip-button>
             </q-td>
           </template>
         </q-table>

--- a/packages/client/src/pages/manage-users.vue
+++ b/packages/client/src/pages/manage-users.vue
@@ -289,12 +289,14 @@ const columns = computed<QTableColumn<CustomerFragment>[]>(() => [
     field: "firstname",
     label: t("manageUsers.fields.firstName"),
     align: "left",
+    classes: "max-width-160 ellipsis",
   },
   {
     name: "last-name",
     field: "lastname",
     label: t("manageUsers.fields.lastName"),
     align: "left",
+    classes: "max-width-160 ellipsis",
   },
   {
     name: "phone-number",

--- a/packages/client/src/pages/my-books.vue
+++ b/packages/client/src/pages/my-books.vue
@@ -49,7 +49,6 @@
             :filter="searchQuery"
             :loading="loading"
             :rows="tableRowsByTab[tab]"
-            :rows-per-page-options="[0]"
             class="col q-pt-sm"
           >
             <template v-if="tab === BooksTab.DELIVERED" #header="props">

--- a/packages/client/src/pages/my-books.vue
+++ b/packages/client/src/pages/my-books.vue
@@ -69,6 +69,24 @@
               </q-tr>
             </template>
 
+            <template #body-cell-author="{ value, col }">
+              <q-td :class="col.classes">
+                <q-tooltip>
+                  {{ value }}
+                </q-tooltip>
+                {{ value }}
+              </q-td>
+            </template>
+
+            <template #body-cell-subject="{ value, col }">
+              <q-td :class="col.classes">
+                <q-tooltip>
+                  {{ value }}
+                </q-tooltip>
+                {{ value }}
+              </q-td>
+            </template>
+
             <template
               v-if="tab === BooksTab.DELIVERED"
               #body-cell-status="{ row }"
@@ -251,6 +269,7 @@ const commonColumns = computed<QTableColumn<TablesRowsTypes>[]>(() => [
     field: ({ book }) => book.title,
     label: t("book.fields.title"),
     align: "left",
+    classes: "text-wrap",
   },
 ]);
 

--- a/packages/client/src/pages/my-books.vue
+++ b/packages/client/src/pages/my-books.vue
@@ -170,6 +170,7 @@ import ChipButton from "src/components/manage-users/chip-button.vue";
 import DialogTable from "src/components/manage-users/dialog-table.vue";
 import StatusChip from "src/components/manage-users/status-chip.vue";
 import { formatPrice } from "src/composables/use-misc-formats";
+import { discountedPrice } from "src/helpers/book-copy";
 import { BooksTab } from "src/models/book";
 import { AvailableRouteNames } from "src/models/routes";
 import { useAuthService } from "src/services/auth";
@@ -297,8 +298,7 @@ const columns = computed<Record<BooksTab, QTableColumn<TablesRowsTypes>[]>>(
         field: ({ book }) => book.originalPrice,
         label: t("myBooks.receivedAmount"),
         align: "left",
-        // TODO: change price to the right calculation
-        format: formatPrice,
+        format: (val: number) => discountedPrice(val, "buy"),
       },
     ],
     [BooksTab.PURCHASED]: [
@@ -306,11 +306,10 @@ const columns = computed<Record<BooksTab, QTableColumn<TablesRowsTypes>[]>>(
       coverPriceColumn.value,
       {
         name: "paid-price",
-        // TODO: update to correct field
         field: ({ book }) => book.originalPrice,
         label: t("myBooks.priceYouPaid"),
         align: "left",
-        format: formatPrice,
+        format: (val: number) => discountedPrice(val, "sell"),
       },
     ],
     [BooksTab.REQUESTED]: [
@@ -327,7 +326,7 @@ const columns = computed<Record<BooksTab, QTableColumn<TablesRowsTypes>[]>>(
         field: ({ book }) => book.originalPrice,
         label: t("myBooks.price"),
         align: "left",
-        format: formatPrice,
+        format: (val: number) => discountedPrice(val, "sell"),
       },
       {
         name: "reserve",
@@ -348,7 +347,7 @@ const columns = computed<Record<BooksTab, QTableColumn<TablesRowsTypes>[]>>(
         field: ({ book }) => book.originalPrice,
         label: t("myBooks.price"),
         align: "left",
-        format: formatPrice,
+        format: (val: number) => discountedPrice(val, "sell"),
       },
       {
         name: "actions",

--- a/packages/client/src/pages/my-books.vue
+++ b/packages/client/src/pages/my-books.vue
@@ -69,21 +69,11 @@
             </template>
 
             <template #body-cell-author="{ value, col }">
-              <q-td :class="col.classes">
-                <q-tooltip>
-                  {{ value }}
-                </q-tooltip>
-                {{ value }}
-              </q-td>
+              <table-cell-with-tooltip :class="col.classes" :value="value" />
             </template>
 
             <template #body-cell-subject="{ value, col }">
-              <q-td :class="col.classes">
-                <q-tooltip>
-                  {{ value }}
-                </q-tooltip>
-                {{ value }}
-              </q-td>
+              <table-cell-with-tooltip :class="col.classes" :value="value" />
             </template>
 
             <template
@@ -169,6 +159,7 @@ import { useRoute, useRouter } from "vue-router";
 import ChipButton from "src/components/manage-users/chip-button.vue";
 import DialogTable from "src/components/manage-users/dialog-table.vue";
 import StatusChip from "src/components/manage-users/status-chip.vue";
+import TableCellWithTooltip from "src/components/manage-users/table-cell-with-tooltip.vue";
 import { formatPrice } from "src/composables/use-misc-formats";
 import { discountedPrice } from "src/helpers/book-copy";
 import { BooksTab } from "src/models/book";

--- a/packages/client/src/pages/reserve-books.vue
+++ b/packages/client/src/pages/reserve-books.vue
@@ -45,21 +45,11 @@
         @request="onRequest"
       >
         <template #body-cell-author="{ value, col }">
-          <q-td :class="col.classes">
-            <q-tooltip>
-              {{ value }}
-            </q-tooltip>
-            {{ value }}
-          </q-td>
+          <table-cell-with-tooltip :class="col.classes" :value="value" />
         </template>
 
         <template #body-cell-subject="{ value, col }">
-          <q-td :class="col.classes">
-            <q-tooltip>
-              {{ value }}
-            </q-tooltip>
-            {{ value }}
-          </q-td>
+          <table-cell-with-tooltip :class="col.classes" :value="value" />
         </template>
 
         <template #body-cell-availability="{ value }">
@@ -101,6 +91,7 @@ import { BookWithAvailableCopiesFragment } from "src/services/cart.graphql";
 import { useRequestService } from "src/services/request";
 import { useReservationService } from "src/services/reservation";
 import { useRetailLocationService } from "src/services/retail-location";
+import tableCellWithTooltip from "./table-cell-with-tooltip.vue";
 
 const { user } = useAuthService();
 const { selectedLocation } = useRetailLocationService();

--- a/packages/client/src/pages/reserve-books.vue
+++ b/packages/client/src/pages/reserve-books.vue
@@ -44,6 +44,24 @@
         class="col"
         @request="onRequest"
       >
+        <template #body-cell-author="{ value, col }">
+          <q-td :class="col.classes">
+            <q-tooltip>
+              {{ value }}
+            </q-tooltip>
+            {{ value }}
+          </q-td>
+        </template>
+
+        <template #body-cell-subject="{ value, col }">
+          <q-td :class="col.classes">
+            <q-tooltip>
+              {{ value }}
+            </q-tooltip>
+            {{ value }}
+          </q-td>
+        </template>
+
         <template #body-cell-availability="{ value }">
           <q-td>
             <status-chip :value="value" />
@@ -123,18 +141,21 @@ const columns = computed<QTableColumn<BookWithAvailableCopiesFragment>[]>(
       field: "authorsFullName",
       label: t("book.fields.author"),
       align: "left",
+      classes: "max-width-160 ellipsis",
     },
     {
       name: "subject",
       field: "subject",
       label: t("book.fields.subject"),
       align: "left",
+      classes: "max-width-160 ellipsis",
     },
     {
       name: "title",
       field: "title",
       label: t("book.fields.title"),
       align: "left",
+      classes: "text-wrap",
     },
     {
       name: "availability",
@@ -152,11 +173,11 @@ const columns = computed<QTableColumn<BookWithAvailableCopiesFragment>[]>(
     },
     {
       name: "price",
-      // TODO: add correct calculation
-      field: ({ originalPrice }) => originalPrice,
+      // FIXME: add correct field and enable format
+      field: () => undefined,
       label: t("book.fields.price"),
       align: "left",
-      format: formatPrice,
+      // format: formatPrice,
     },
     {
       name: "available-copies",

--- a/packages/client/src/pages/reserve-books.vue
+++ b/packages/client/src/pages/reserve-books.vue
@@ -79,6 +79,7 @@ import CardTableHeader from "src/components/manage-users/card-table-header.vue";
 import ChipButton from "src/components/manage-users/chip-button.vue";
 import DialogTable from "src/components/manage-users/dialog-table.vue";
 import StatusChip from "src/components/manage-users/status-chip.vue";
+import TableCellWithTooltip from "src/components/manage-users/table-cell-with-tooltip.vue";
 import ReserveBooksByClassDialog from "src/components/reserve-books-by-class-dialog.vue";
 import { formatPrice } from "src/composables/use-misc-formats";
 import { discountedPrice } from "src/helpers/book-copy";
@@ -91,7 +92,6 @@ import { BookWithAvailableCopiesFragment } from "src/services/cart.graphql";
 import { useRequestService } from "src/services/request";
 import { useReservationService } from "src/services/reservation";
 import { useRetailLocationService } from "src/services/retail-location";
-import tableCellWithTooltip from "./table-cell-with-tooltip.vue";
 
 const { user } = useAuthService();
 const { selectedLocation } = useRetailLocationService();

--- a/packages/client/src/pages/reserve-books.vue
+++ b/packages/client/src/pages/reserve-books.vue
@@ -91,6 +91,7 @@ import DialogTable from "src/components/manage-users/dialog-table.vue";
 import StatusChip from "src/components/manage-users/status-chip.vue";
 import ReserveBooksByClassDialog from "src/components/reserve-books-by-class-dialog.vue";
 import { formatPrice } from "src/composables/use-misc-formats";
+import { discountedPrice } from "src/helpers/book-copy";
 import { BooksTab, CourseDetails } from "src/models/book";
 import { AvailableRouteNames } from "src/models/routes";
 import { useAuthService } from "src/services/auth";
@@ -173,11 +174,10 @@ const columns = computed<QTableColumn<BookWithAvailableCopiesFragment>[]>(
     },
     {
       name: "price",
-      // FIXME: add correct field and enable format
-      field: () => undefined,
+      field: "originalPrice",
       label: t("book.fields.price"),
       align: "left",
-      // format: formatPrice,
+      format: (val: number) => discountedPrice(val, "sell"),
     },
     {
       name: "available-copies",

--- a/packages/client/src/pages/salable-books.vue
+++ b/packages/client/src/pages/salable-books.vue
@@ -42,7 +42,6 @@
             // prettier-ignore
             rows as readonly BookWithStatus[]
           "
-          :rows-per-page-options="[0]"
           class="flex-delegate-height-management"
         >
           <template #body="{ row, cols }">

--- a/packages/client/src/pages/salable-books.vue
+++ b/packages/client/src/pages/salable-books.vue
@@ -61,9 +61,13 @@
               </q-td>
             </q-tr>
             <q-tr v-else>
-              <q-td v-for="col in cols" :key="col.name">
+              <q-td
+                v-for="{ name, value, classes } in cols"
+                :key="name"
+                :class="classes"
+              >
                 <span
-                  v-if="col.name === 'status'"
+                  v-if="name === 'status'"
                   :class="`text-${
                     row.status === AcceptanceStatus.ACCEPTED
                       ? 'positive'
@@ -73,7 +77,10 @@
                   {{ $t(`salableBooks.acceptanceStatus.${row.status}`) }}
                 </span>
                 <span v-else>
-                  {{ col.value }}
+                  <q-tooltip v-if="['subject', 'author'].includes(name)">
+                    {{ value }}
+                  </q-tooltip>
+                  {{ value }}
                 </span>
               </q-td>
             </q-tr>
@@ -116,18 +123,21 @@ const columns = computed<QTableColumn<BookWithStatus>[]>(() => [
     field: "authorsFullName",
     label: t("book.fields.author"),
     align: "left",
+    classes: "max-width-160 ellipsis",
   },
   {
     name: "subject",
     field: "subject",
     label: t("book.fields.subject"),
     align: "left",
+    classes: "max-width-160 ellipsis",
   },
   {
     name: "title",
     field: "title",
     label: t("book.fields.title"),
     align: "left",
+    classes: "text-wrap",
   },
 ]);
 

--- a/packages/client/src/pages/select-location.vue
+++ b/packages/client/src/pages/select-location.vue
@@ -2,6 +2,9 @@
   <q-layout view="lHh Lpr lFf">
     <q-page-container class="layout-background">
       <q-page class="column fit flex-center q-pa-xl">
+        <language-dropdown-btn class="fixed-top-right q-ma-md" />
+        <q-spinner v-if="loading" />
+
         <h4 class="m-mb-36 q-mt-none readability-max-width text-accent">
           {{ t("home.title") }}
         </h4>
@@ -31,6 +34,7 @@
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import ActionBox from "src/components/action-box.vue";
+import LanguageDropdownBtn from "src/components/language-dropdown-btn.vue";
 import { AvailableRouteNames } from "src/models/routes";
 import { useRetailLocationService } from "src/services/retail-location";
 import { RetailLocationFragment } from "src/services/retail-location.graphql";

--- a/packages/client/src/pages/warehouse.vue
+++ b/packages/client/src/pages/warehouse.vue
@@ -18,6 +18,8 @@
             @click="swapView()"
           />
         </template>
+
+        <!-- TODO: add a button to check the other warehouse out -->
       </header-search-bar-filters>
 
       <dialog-table

--- a/packages/client/src/pages/warehouse.vue
+++ b/packages/client/src/pages/warehouse.vue
@@ -61,9 +61,9 @@
             </q-td>
 
             <q-td
-              v-for="{ name, field, align } in columns"
+              v-for="{ name, field, align, classes } in columns"
               :key="name"
-              :class="align ? `text-${align}` : 'text-left'"
+              :class="[align ? `text-${align}` : 'text-left', classes]"
               :colspan="name === 'title' ? 2 : 1"
               auto-width
             >
@@ -77,6 +77,9 @@
                     'text-underline': name === 'available-copies',
                   }"
                 >
+                  <q-tooltip v-if="['subject', 'author'].includes(name)">
+                    {{ getFieldValue(field, props.row) }}
+                  </q-tooltip>
                   {{ getFieldValue(field, props.row) }}
                 </span>
               </template>
@@ -210,12 +213,14 @@ const columns = computed<QTableColumn<BookWithAvailableCopiesFragment>[]>(
       field: "authorsFullName",
       label: t("book.fields.author"),
       align: "left",
+      classes: "max-width-160 ellipsis",
     },
     {
       name: "subject",
       field: "subject",
       label: t("book.fields.subject"),
       align: "left",
+      classes: "max-width-160 ellipsis",
     },
     {
       name: "status",
@@ -234,6 +239,7 @@ const columns = computed<QTableColumn<BookWithAvailableCopiesFragment>[]>(
       field: "title",
       label: t("book.fields.title"),
       align: "left",
+      classes: "text-wrap",
     },
     {
       name: "problems",

--- a/packages/client/src/pages/warehouse.vue
+++ b/packages/client/src/pages/warehouse.vue
@@ -7,55 +7,16 @@
       >
         <template #side-actions>
           <q-btn
-            v-if="screenWidth === WidthSize.SM"
-            :icon="mdiDotsVertical"
-            color="black-54"
-            round
-            flat
-          >
-            <q-menu>
-              <q-item clickable @click="swapView()">
-                <q-item-section>
-                  <q-item-label>
-                    {{
-                      t(
-                        `warehouse.${isSortedByCopyCode ? "sortByISBN" : "sortByCopyCode"}`,
-                      )
-                    }}
-                  </q-item-label>
-                </q-item-section>
-              </q-item>
-
-              <q-item clickable @click="checkOtherWarehouse()">
-                <q-item-section>
-                  <q-item-label>
-                    {{ t("warehouse.checkOtherWarehouse", [otherCityName]) }}
-                  </q-item-label>
-                </q-item-section>
-              </q-item>
-            </q-menu>
-          </q-btn>
-
-          <template v-else>
-            <q-btn
-              :icon="mdiSort"
-              :label="
-                t(
-                  `warehouse.${isSortedByCopyCode ? 'sortByISBN' : 'sortByCopyCode'}`,
-                )
-              "
-              no-wrap
-              outline
-              @click="swapView()"
-            />
-            <q-btn
-              :icon-right="mdiArrowRight"
-              :label="t('warehouse.checkOtherWarehouse', [otherCityName])"
-              color="accent"
-              no-wrap
-              @click="checkOtherWarehouse()"
-            />
-          </template>
+            :icon="mdiSort"
+            :label="
+              t(
+                `warehouse.${isSortedByCopyCode ? 'sortByISBN' : 'sortByCopyCode'}`,
+              )
+            "
+            no-wrap
+            outline
+            @click="swapView()"
+          />
         </template>
       </header-search-bar-filters>
 
@@ -174,10 +135,8 @@
 
 <script setup lang="ts">
 import {
-  mdiArrowRight,
   mdiChevronDown,
   mdiChevronUp,
-  mdiDotsVertical,
   mdiHistory,
   mdiSort,
 } from "@quasar/extras/mdi-v7";
@@ -192,7 +151,6 @@ import ProblemsHistoryDialog from "src/components/manage-users/problems-history-
 import StatusChip from "src/components/manage-users/status-chip.vue";
 import ProblemsButton from "src/components/problems-button.vue";
 import { useTableFilters } from "src/composables/use-table-filters";
-import { WidthSize, useScreenWidth } from "src/helpers/screen";
 import { getFieldValue } from "src/helpers/table-helpers";
 import {
   BookCopyDetailsFragment,
@@ -202,7 +160,7 @@ import { useGetBooksWithAvailableCopiesQuery } from "src/services/book.graphql";
 import { BookWithAvailableCopiesFragment } from "src/services/cart.graphql";
 import { useRetailLocationService } from "src/services/retail-location";
 
-const { selectedLocation, retailLocations } = useRetailLocationService();
+const { selectedLocation } = useRetailLocationService();
 
 const booksPage = ref(0);
 const copyPage = ref(0);
@@ -231,11 +189,6 @@ const {
 });
 
 const { t } = useI18n();
-
-// Setting this so that the side buttons don't overflow to two rows when the screen
-// is below the minimum width to hold them in a single row
-const smallScreenBreakpoint = 1802;
-const screenWidth = useScreenWidth(smallScreenBreakpoint);
 
 const isSortedByCopyCode = ref(false);
 
@@ -394,15 +347,6 @@ const onCopyRequest: QTableProps["onRequest"] = async ({
   copyLoading.value = false;
 };
 
-// We know that there are only two retail locations in the array,
-// so we filter out the currently selected one
-const otherCityName = computed(
-  () =>
-    retailLocations.value.filter(
-      (location) => location.id !== selectedLocation.value.id,
-    )[0]?.name,
-);
-
 function swapView() {
   isSortedByCopyCode.value = !isSortedByCopyCode.value;
 
@@ -418,10 +362,6 @@ function swapView() {
   } else {
     booksPage.value = 0;
   }
-}
-
-function checkOtherWarehouse() {
-  // FIXME: check other warehouse
 }
 
 function openHistory(bookCopy: BookCopyDetailsFragment) {

--- a/packages/client/src/pages/warehouse.vue
+++ b/packages/client/src/pages/warehouse.vue
@@ -90,6 +90,7 @@
             <book-copy-details-table
               :book-copy-columns="bookCopyColumns"
               :book-id="props.row.id"
+              :show-only-available="booleanFilters?.isAvailable"
               @open-history="(bookCopy) => openHistory(bookCopy)"
               @update-problems="refetchBooks()"
             />
@@ -197,8 +198,13 @@ const isSortedByCopyCode = ref(false);
 
 const tableRef = ref<QTable>();
 
-const { refetchFilterProxy, filterOptions, tableFilter, filterMethod } =
-  useTableFilters("warehouse.filters", true);
+const {
+  refetchFilterProxy,
+  filterOptions,
+  tableFilter,
+  filterMethod,
+  booleanFilters,
+} = useTableFilters("warehouse.filters", true);
 
 const columns = computed<QTableColumn<BookWithAvailableCopiesFragment>[]>(
   () => [
@@ -326,7 +332,7 @@ const onBooksRequest: QTableProps["onRequest"] = async ({
     retailLocationId: selectedLocation.value.id,
     page: page - 1,
     rows: rowsPerPage,
-    filter: refetchFilterProxy.value,
+    filter: { ...refetchFilterProxy.value, isAvailable: true },
   });
 
   booksPagination.value.rowsNumber = books.value?.rowsCount;

--- a/packages/client/src/services/auth.ts
+++ b/packages/client/src/services/auth.ts
@@ -5,6 +5,7 @@ import { LocalStorage } from "quasar";
 import { computed, readonly, ref, watch } from "vue";
 import { NavigationGuard, Router, useRouter } from "vue-router";
 import { UpdateUserPayload } from "src/@generated/graphql";
+import { MessageLanguages, STORAGE_LOCALE_KEY } from "src/boot/i18n";
 import { AvailableRouteNames } from "src/models/routes";
 import { useRetailLocationService } from "src/services/retail-location";
 import {
@@ -211,8 +212,12 @@ export function useLogoutMutation(router = useRouter()) {
     }
     token.value = undefined;
     user.value = undefined;
-    // Wipe out the storage completely to avoid user data being leaked (settings, etc)
+    // Wipe out the storage completely to avoid user data being leaked (settings, etc), only keep the locale
+    const locale = LocalStorage.getItem<MessageLanguages>(STORAGE_LOCALE_KEY);
     LocalStorage.clear();
+    if (locale) {
+      LocalStorage.set(STORAGE_LOCALE_KEY, locale);
+    }
     void client.clearStore();
     if (selectedLocationId.value) {
       void router.push({

--- a/packages/client/src/services/book-copy.graphql
+++ b/packages/client/src/services/book-copy.graphql
@@ -53,6 +53,8 @@ fragment BookCopyDetails on BookCopy {
   sales {
     refundedAt
   }
+  settledAt
+  settledById
 }
 
 query getBookCopies($bookId: String!) {

--- a/packages/client/src/services/cart.graphql
+++ b/packages/client/src/services/cart.graphql
@@ -5,7 +5,10 @@ fragment CartSummary on Cart {
 fragment BookWithAvailableCopies on Book {
   ...BookSummary
   copies(isAvailable: true) {
-    ...BookCopySummary
+    ...BookCopyDetails
+    owner {
+      ...UserSummary
+    }
   }
 }
 

--- a/packages/client/src/services/retail-location.graphql
+++ b/packages/client/src/services/retail-location.graphql
@@ -7,6 +7,14 @@ fragment Theme on Theme {
   }
 }
 
+fragment RetailLocationSettings on RetailLocation {
+  buyRate
+  sellRate
+  payOffEnabled
+  maxBookingDays
+  warehouseMaxBlockSize
+}
+
 fragment RetailLocation on RetailLocation {
   id
   name
@@ -17,11 +25,7 @@ fragment RetailLocation on RetailLocation {
   facebookLink
   whoAreWeContent
 
-  buyRate
-  sellRate
-  payOffEnabled
-  maxBookingDays
-  warehouseMaxBlockSize
+  ...RetailLocationSettings
 
   theme {
     ...Theme
@@ -44,6 +48,6 @@ mutation updateRetailLocationSettings(
   $input: UpdateRetailLocationSettingsInput!
 ) {
   updateRetailLocationSettings(input: $input) {
-    ...RetailLocation
+    ...RetailLocationSettings
   }
 }

--- a/packages/client/src/services/retail-location.graphql
+++ b/packages/client/src/services/retail-location.graphql
@@ -48,6 +48,7 @@ mutation updateRetailLocationSettings(
   $input: UpdateRetailLocationSettingsInput!
 ) {
   updateRetailLocationSettings(input: $input) {
+    id # include the id so that the cache gets updated automatically
     ...RetailLocationSettings
   }
 }

--- a/packages/server/src/modules/retail-location/retail-location.input.ts
+++ b/packages/server/src/modules/retail-location/retail-location.input.ts
@@ -8,7 +8,13 @@ export class UpdateRetailLocationSettingsInput extends IntersectionType(
   LocationBoundInput,
   PickType(
     RetailLocation,
-    ["maxBookingDays", "payOffEnabled", "warehouseMaxBlockSize"],
+    [
+      "maxBookingDays",
+      "payOffEnabled",
+      "warehouseMaxBlockSize",
+      "buyRate",
+      "sellRate",
+    ],
     InputType,
   ),
 ) {}

--- a/packages/server/src/modules/retail-location/retail-location.resolver.ts
+++ b/packages/server/src/modules/retail-location/retail-location.resolver.ts
@@ -1,4 +1,3 @@
-import { isDeepStrictEqual } from "util";
 import { BadRequestException } from "@nestjs/common";
 import { Args, Mutation, Query, Resolver } from "@nestjs/graphql";
 import { Prisma, User } from "@prisma/client";
@@ -81,6 +80,8 @@ export class RetailLocationResolver {
       payOffEnabled,
       retailLocationId,
       warehouseMaxBlockSize,
+      buyRate,
+      sellRate,
     }: UpdateRetailLocationSettingsInput,
     @CurrentUser() user: User,
   ) {
@@ -91,35 +92,14 @@ export class RetailLocationResolver {
     });
 
     if (
-      !maxBookingDays ||
-      !warehouseMaxBlockSize ||
-      maxBookingDays <= 0 ||
-      warehouseMaxBlockSize <= 0
+      Object.values({
+        maxBookingDays,
+        warehouseMaxBlockSize,
+        buyRate,
+        sellRate,
+      }).some((value) => !value || value < 0)
     ) {
       throw new BadRequestException("Invalid settings values");
-    }
-
-    const existingSettings = await this.prisma.retailLocation.findUniqueOrThrow(
-      {
-        where: {
-          id: retailLocationId,
-        },
-        select: {
-          maxBookingDays: true,
-          payOffEnabled: true,
-          warehouseMaxBlockSize: true,
-        },
-      },
-    );
-
-    if (
-      isDeepStrictEqual(existingSettings, {
-        maxBookingDays,
-        payOffEnabled,
-        warehouseMaxBlockSize,
-      })
-    ) {
-      return;
     }
 
     return await this.prisma.retailLocation.update({
@@ -130,6 +110,8 @@ export class RetailLocationResolver {
         maxBookingDays,
         warehouseMaxBlockSize,
         payOffEnabled,
+        buyRate,
+        sellRate,
       },
     });
   }

--- a/packages/server/src/modules/user/user.resolver.ts
+++ b/packages/server/src/modules/user/user.resolver.ts
@@ -380,6 +380,7 @@ export class UserResolver {
         "Confirmation password doesn't match with provided password!",
       );
     }
+    // TODO: require delegate full name when the user is a minor
 
     const userIsAdmin = await this.authService.userIsAdmin(
       currentUser.id,
@@ -428,6 +429,17 @@ export class UserResolver {
     ) {
       throw new UnprocessableEntityException(
         "Confirmation password doesn't match with provided password!",
+      );
+    }
+    if (
+      payloadRest.dateOfBirth &&
+      new Date().getUTCFullYear() -
+        new Date(payloadRest.dateOfBirth).getUTCFullYear() <
+        18 &&
+      (!payloadRest.delegate || payloadRest.delegate.length === 0)
+    ) {
+      throw new UnprocessableEntityException(
+        "Trying to register a user which is a minor, but not providing an adult delegate for the user.",
       );
     }
     const userIsAdmin = await this.authService.userIsAdmin(


### PR DESCRIPTION
## What it does
This PR fixes the following issues:
- #46 
- #50 
- #51 
- #52 
- #47

In addition, it also addresses the following problems:
- Admins can now update the `sellRate` and `purchaseRate` settings at any time, as it is simply entrusted to them not to change them during the Mercatino's activity period.
- A delegate's full name is now mandatory for updating users who are less than 18 years old.
- It is now possible to add multiple copies of the same book to the customer book withdrawals list.
- The sale and purchase prices are now calculated and displayed correctly everywhere.

## How to test it
Check for each issue to be fixed properly; especially important to check the prices display and calculation mechanism

### Additional information
There currently are no user registration arguments that permit the implementation of the constraint for the delegate requirement for minor users. Once the new registration mechanism is handled, the relative check must be added as well. A `TODO` was added in `packages/server/src/modules/user/user.resolver.ts` for this.
Cc @yusufkandemir @SirAuron

Regarding #46: a language switcher has been added on both `/select-locations` and the header of the unlogged UI; this component has not yet been designed so it may be subject to changes in the future.

For completeness's sake: I noticed while working on these tasks that there is also some update logic I missed in #39 about updating the payoff dialog data once the settlement of a user has been done.