### PR TITLE
feat(client&server): add account deletion and data downloading

### DIFF
--- a/packages/client/src/components/manage-users/edit-user-details-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-details-dialog.vue
@@ -6,6 +6,7 @@
       @submit="onDialogOK(newUserData)"
       @cancel="onDialogCancel"
     >
+      <!-- bottom-slots prop is used when there are no rules/hint/etc. to unify bottom padding with the ones that do have -->
       <q-card-section class="column gap-4 no-wrap">
         <q-input
           v-model="newUserData.firstname"
@@ -37,60 +38,62 @@
           mask="phone"
           outlined
         />
-        <q-item-section class="column gap-24 no-padding no-wrap">
-          <q-input
-            v-model="newUserData.password"
-            :label="$t('auth.password')"
-            :rules="newUserData.password ? [validatePasswordRule] : undefined"
-            :type="hidePassword ? 'password' : 'text'"
-            autocomplete="new-password"
-            outlined
-          >
-            <template #append>
-              <q-icon
-                :name="hidePassword ? mdiEyeOff : mdiEye"
-                class="cursor-pointer"
-                @click="hidePassword = !hidePassword"
-              />
-            </template>
-          </q-input>
-          <q-input
-            v-model="newUserData.passwordConfirmation"
-            :label="$t('auth.confirmPassword')"
-            :rules="
-              newUserData.password
-                ? [
-                    makeValueMatchRule(
-                      newUserData.password,
-                      $t('auth.passwordDoNotMatch'),
-                    ),
-                  ]
-                : undefined
-            "
-            :type="hideConfirm ? 'password' : 'text'"
-            autocomplete="new-password"
-            outlined
-          >
-            <template #append>
-              <q-icon
-                :name="hideConfirm ? mdiEyeOff : mdiEye"
-                class="cursor-pointer"
-                @click="hideConfirm = !hideConfirm"
-              />
-            </template>
-          </q-input>
-          <q-input
-            v-model="newUserData.notes"
-            :label="$t('manageUsers.editUser.notes')"
-            clearable
-            outlined
-          />
-          <q-checkbox
-            v-model="newUserData.discount"
-            :disable="!hasAdminRole"
-            :label="$t('manageUsers.editUser.discount')"
-          />
-        </q-item-section>
+        <q-input
+          v-model="newUserData.password"
+          :label="$t('auth.password')"
+          :rules="newUserData.password ? [validatePasswordRule] : undefined"
+          :type="hidePassword ? 'password' : 'text'"
+          autocomplete="new-password"
+          outlined
+          bottom-slots
+        >
+          <template #append>
+            <q-icon
+              :name="hidePassword ? mdiEyeOff : mdiEye"
+              class="cursor-pointer"
+              @click="hidePassword = !hidePassword"
+            />
+          </template>
+        </q-input>
+        <q-input
+          v-model="newUserData.passwordConfirmation"
+          :label="$t('auth.confirmPassword')"
+          :rules="
+            newUserData.password
+              ? [
+                  makeValueMatchRule(
+                    newUserData.password,
+                    $t('auth.passwordDoNotMatch'),
+                  ),
+                ]
+              : undefined
+          "
+          :type="hideConfirm ? 'password' : 'text'"
+          autocomplete="new-password"
+          outlined
+          bottom-slots
+        >
+          <template #append>
+            <q-icon
+              :name="hideConfirm ? mdiEyeOff : mdiEye"
+              class="cursor-pointer"
+              @click="hideConfirm = !hideConfirm"
+            />
+          </template>
+        </q-input>
+        <q-input
+          v-model="newUserData.notes"
+          :label="$t('manageUsers.editUser.notes')"
+          clearable
+          outlined
+          bottom-slots
+        />
+        <q-checkbox
+          v-model="newUserData.discount"
+          :disable="!hasAdminRole"
+          :label="$t('manageUsers.editUser.discount')"
+          bottom-slots
+        />
       </q-card-section>
     </k-dialog-form-card>
   </q-dialog>

--- a/packages/client/src/components/manage-users/table-cell-with-dialog.vue
+++ b/packages/client/src/components/manage-users/table-cell-with-dialog.vue
@@ -1,6 +1,9 @@
 <template>
   <q-td>
-    <span v-if="value <= 0 && !clickableWhenZero" class="text-body2">
+    <span
+      v-if="disable || (value <= 0 && !clickableWhenZero)"
+      class="text-body2"
+    >
       {{ value }}
     </span>
     <q-btn v-else square flat class="absolute-full">
@@ -34,5 +37,6 @@ defineProps<{
   value: number;
   secondaryValue?: number;
   clickableWhenZero?: boolean;
+  disable?: boolean;
 }>();
 </script>

--- a/packages/client/src/components/manage-users/table-cell-with-dialog.vue
+++ b/packages/client/src/components/manage-users/table-cell-with-dialog.vue
@@ -1,10 +1,11 @@
 <template>
-  <q-td>
+  <q-td
+    :class="{ 'cursor-not-allowed': disable }"
+    @click="!disable ? emit('click', $event) : undefined"
+  >
     <span
       v-if="disable || (value <= 0 && !clickableWhenZero)"
       class="text-body2"
-      :class="{ 'cursor-not-allowed': disable }"
-      @click.stop
     >
       {{ value }}
     </span>
@@ -40,5 +41,9 @@ defineProps<{
   secondaryValue?: number;
   clickableWhenZero?: boolean;
   disable?: boolean;
+}>();
+
+const emit = defineEmits<{
+  click: [MouseEvent];
 }>();
 </script>

--- a/packages/client/src/components/manage-users/table-cell-with-dialog.vue
+++ b/packages/client/src/components/manage-users/table-cell-with-dialog.vue
@@ -3,6 +3,8 @@
     <span
       v-if="disable || (value <= 0 && !clickableWhenZero)"
       class="text-body2"
+      :class="{ 'cursor-not-allowed': disable }"
+      @click.stop
     >
       {{ value }}
     </span>

--- a/packages/client/src/i18n/en-US/auth.ts
+++ b/packages/client/src/i18n/en-US/auth.ts
@@ -43,9 +43,11 @@ export default {
   delegateLabel:
     "The first name and last name of an adult person with delegation to deliver and retrieve books at Mercatino del Libro's retail location",
   editMyData: "Edit my data",
-  deleteAccount: "Delete your account",
   confirmEmail: "Confirm Email",
   emailsDoNotMatch: "The emails do not match",
+  downloadUserData: "Download your data",
+  deleteAccount: "Delete your account",
+  cancelAccountDeletion: "Cancel account deletion",
   deleteAccountDialog: {
     disclaimer:
       "Attention, you are about to delete your user account permanently. In 7 days your personal information will be removed from our database and your account will become permanently inaccessible. Are you sure you want to proceed?",

--- a/packages/client/src/i18n/en-US/manage-users.ts
+++ b/packages/client/src/i18n/en-US/manage-users.ts
@@ -47,10 +47,14 @@ export default {
 
     downloadData: "Download Data",
     downloadDataSuccess: "The account data will be downloaded shortly",
+    downloadDataFailed:
+      "Could not download the account data. Please contact the support.",
     deleteUser: "Delete User",
     deleteUserSuccess: "The user has been scheduled for deletion in 7 days",
+    deleteUserFailed: "Could not delete the user",
     cancelUserDeletion: "Cancel User Deletion",
     cancelUserDeletionSuccess: "The user's deletion has been canceled",
+    cancelUserDeletionFailed: "Could not cancel the user's deletion",
   },
   inRetrieval: "In retrieval",
   retrieved: "Retrieved",

--- a/packages/client/src/i18n/en-US/manage-users.ts
+++ b/packages/client/src/i18n/en-US/manage-users.ts
@@ -46,8 +46,11 @@ export default {
     notes: "Notes",
 
     downloadData: "Download Data",
+    downloadDataSuccess: "The account data will be downloaded shortly",
     deleteUser: "Delete User",
+    deleteUserSuccess: "The user has been scheduled for deletion in 7 days",
     cancelUserDeletion: "Cancel User Deletion",
+    cancelUserDeletionSuccess: "The user's deletion has been canceled",
   },
   inRetrieval: "In retrieval",
   retrieved: "Retrieved",

--- a/packages/client/src/i18n/en-US/manage-users.ts
+++ b/packages/client/src/i18n/en-US/manage-users.ts
@@ -44,6 +44,10 @@ export default {
     createUser: "Create a New User",
     discount: "Apply ISEE/volunteer discount",
     notes: "Notes",
+
+    downloadData: "Download Data",
+    deleteUser: "Delete User",
+    cancelUserDeletion: "Cancel User Deletion",
   },
   inRetrieval: "In retrieval",
   retrieved: "Retrieved",

--- a/packages/client/src/i18n/it/auth.ts
+++ b/packages/client/src/i18n/it/auth.ts
@@ -45,9 +45,11 @@ export default {
   delegateLabel:
     "Il nome e il cognome di una persona maggiorenne con delega di consegnare e ritirare libri presso la sede del Mercatino del Libro",
   editMyData: "Modifica i miei dati",
-  deleteAccount: "Elimina il tuo account",
   confirmEmail: "Conferma Email",
   emailsDoNotMatch: "Le email non coincidono",
+  downloadUserData: "Scarica i tuoi dati",
+  deleteAccount: "Elimina il tuo account",
+  cancelAccountDeletion: "Annulla l'eliminazione dell'account",
   deleteAccountDialog: {
     disclaimer:
       "Attenzione, stai per eliminare definitivamente il tuo account utente. Tra 7 giorni le tue informazioni personali verranno rimosse dal nostro database e il tuo account diventerà permanentemente inaccessibile. Sei sicuro di voler continuare?",

--- a/packages/client/src/i18n/it/manage-users.ts
+++ b/packages/client/src/i18n/it/manage-users.ts
@@ -44,6 +44,10 @@ export default {
     createUser: "Crea un Nuovo Utente",
     discount: "Applica sconto ISEE/volontario",
     notes: "Note",
+
+    downloadData: "Scarica Dati",
+    deleteUser: "Elimina Utente",
+    cancelUserDeletion: "Annulla Eliminazione Utente",
   },
   inRetrieval: "In ritiro",
   retrieved: "Ritirati",

--- a/packages/client/src/i18n/it/manage-users.ts
+++ b/packages/client/src/i18n/it/manage-users.ts
@@ -46,8 +46,12 @@ export default {
     notes: "Note",
 
     downloadData: "Scarica Dati",
+    downloadDataSuccess: "I dati dell'account verranno scaricati a breve",
     deleteUser: "Elimina Utente",
+    deleteUserSuccess:
+      "L'utente è stato programmato per l'eliminazione tra 7 giorni",
     cancelUserDeletion: "Annulla Eliminazione Utente",
+    cancelUserDeletionSuccess: "L'eliminazione dell'utente è stata annullata",
   },
   inRetrieval: "In ritiro",
   retrieved: "Ritirati",

--- a/packages/client/src/i18n/it/manage-users.ts
+++ b/packages/client/src/i18n/it/manage-users.ts
@@ -47,11 +47,16 @@ export default {
 
     downloadData: "Scarica Dati",
     downloadDataSuccess: "I dati dell'account verranno scaricati a breve",
+    downloadDataFailed:
+      "Non è stato possibile scaricare i dati dell'account. Si prega di contattare il supporto.",
     deleteUser: "Elimina Utente",
     deleteUserSuccess:
       "L'utente è stato programmato per l'eliminazione tra 7 giorni",
+    deleteUserFailed: "Non è stato possibile eliminare l'utente",
     cancelUserDeletion: "Annulla Eliminazione Utente",
     cancelUserDeletionSuccess: "L'eliminazione dell'utente è stata annullata",
+    cancelUserDeletionFailed:
+      "Non è stato possibile annullare l'eliminazione dell'utente",
   },
   inRetrieval: "In ritiro",
   retrieved: "Ritirati",

--- a/packages/client/src/models/user.ts
+++ b/packages/client/src/models/user.ts
@@ -1,6 +1,24 @@
-import { UpdateUserPayload } from "src/@generated/graphql";
+import { RegisterUserPayload, UpdateUserPayload } from "src/@generated/graphql";
 
 export type UserData = Omit<
   UpdateUserPayload,
   "__typename" | "id" | "retailLocationId" | "discount" | "notes"
 > & { email: string; confirmEmail: string };
+
+export type UserDialogPayload =
+  | {
+      type: "create";
+      data: RegisterUserPayload;
+    }
+  | {
+      type: "update";
+      data: UpdateUserPayload;
+    }
+  | {
+      type: "toggleDeletion";
+      data: { id: string };
+    }
+  | {
+      type: "downloadData";
+      data: { id: string };
+    };

--- a/packages/client/src/pages/manage-users.vue
+++ b/packages/client/src/pages/manage-users.vue
@@ -457,8 +457,8 @@ function openEdit({
     },
   }).onOk(async (payload: Exclude<UserDialogPayload, { type: "create" }>) => {
     if (payload.type === "toggleDeletion") {
+      const shouldDelete = !scheduledForDeletionAt;
       try {
-        const shouldDelete = !scheduledForDeletionAt;
         if (shouldDelete) {
           await deleteUserAccount({ input: { userId: id } });
           Notify.create({
@@ -472,8 +472,13 @@ function openEdit({
             message: t("manageUsers.editUser.cancelUserDeletionSuccess"),
           });
         }
-      } catch {
-        notifyError(t("auth.couldNotUpdate"));
+      } catch (error) {
+        console.error(error);
+        if (shouldDelete) {
+          notifyError(t("manageUsers.editUser.deleteUserFailed"));
+        } else {
+          notifyError(t("manageUsers.editUser.cancelUserDeletionFailed"));
+        }
       }
       return;
     }

--- a/packages/client/src/pages/manage-users.vue
+++ b/packages/client/src/pages/manage-users.vue
@@ -186,9 +186,8 @@
           <template #body-cell-pay-off="{ row }">
             <q-td>
               <chip-button
-                :disable="willBeDeleted(row)"
+                :disable="!selectedLocation.payOffEnabled || willBeDeleted(row)"
                 color="primary"
-                :disabled="!selectedLocation.payOffEnabled"
                 :label="$t('manageUsers.payOff')"
                 @click="openPayOff(row)"
               >

--- a/packages/client/src/pages/my-data.vue
+++ b/packages/client/src/pages/my-data.vue
@@ -38,16 +38,23 @@
             :label="t('auth.editMyData')"
             class="q-mb-xl q-mt-md"
             color="primary"
-            @click="modifyUserData()"
+            @click="modifyUserData"
           />
 
           <q-separator />
 
           <q-btn
+            :label="t('auth.downloadUserData')"
+            class="q-mt-xl"
+            color="accent"
+            @click="downloadUserData"
+          />
+
+          <q-btn
             :label="t('auth.deleteAccount')"
             class="q-mt-xl"
             color="accent"
-            @click="deleteAccount()"
+            @click="deleteAccount"
           />
         </template>
 
@@ -183,6 +190,10 @@ function modifyUserData() {
       notifyError(t("auth.couldNotUpdate"));
     }
   });
+}
+
+function downloadUserData() {
+  // TODO: add download of the user's data
 }
 
 function deleteAccount() {

--- a/packages/client/src/pages/my-data.vue
+++ b/packages/client/src/pages/my-data.vue
@@ -36,23 +36,21 @@
 
           <q-btn
             :label="t('auth.editMyData')"
-            class="q-mb-xl q-mt-md"
+            class="q-mt-md"
             color="primary"
             @click="modifyUserData"
           />
 
-          <q-separator />
-
           <q-btn
             :label="t('auth.downloadUserData')"
-            class="q-mt-xl"
+            class="q-mt-md"
             color="accent"
             @click="downloadUserData"
           />
 
           <q-btn
             :label="t('auth.deleteAccount')"
-            class="q-mt-xl"
+            class="q-mt-md"
             color="accent"
             @click="deleteAccount"
           />
@@ -82,11 +80,13 @@ import { UpdateUserPayload } from "src/@generated/graphql";
 import DeleteAccountDialog from "src/components/delete-account-dialog.vue";
 import EditUserDataDialog from "src/components/edit-user-data-dialog.vue";
 import { notifyError } from "src/helpers/error-messages";
-import { useAuthService } from "src/services/auth";
+import { useAuthService, useLogoutMutation } from "src/services/auth";
 import { CurrentUserFragment } from "src/services/auth.graphql";
 import { useRetailLocationService } from "src/services/retail-location";
+import { useDownloadUserData } from "src/services/user";
 import {
   UserFragmentDoc,
+  useDeleteUserAccountMutation,
   useUpdateUserMutation,
 } from "src/services/user.graphql";
 
@@ -192,15 +192,25 @@ function modifyUserData() {
   });
 }
 
-function downloadUserData() {
-  // TODO: add download of the user's data
+const { downloadData } = useDownloadUserData();
+async function downloadUserData() {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  await downloadData(user.value!.id);
 }
 
+const { deleteUserAccount } = useDeleteUserAccountMutation();
+const { logout } = useLogoutMutation();
 function deleteAccount() {
   Dialog.create({
     component: DeleteAccountDialog,
-  }).onOk(() => {
-    // FIXME: add deletion of the user's account and log out
+  }).onOk(async () => {
+    await deleteUserAccount({
+      input: {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        userId: user.value!.id,
+      },
+    });
+    logout();
   });
 }
 </script>

--- a/packages/client/src/services/user.graphql
+++ b/packages/client/src/services/user.graphql
@@ -81,3 +81,23 @@ mutation updateUser($input: UpdateUserPayload!) {
 mutation settleUser($input: SettleUserInput!) {
   settleUser(input: $input)
 }
+
+query getUserData($userId: String!) {
+  userData(userId: $userId)
+}
+
+mutation deleteUserAccount($input: DeleteUserAccountInput!) {
+  # Request just enough data so that the cache gets updated automatically
+  deleteUserAccount(input: $input) {
+    id
+    deletedAt
+  }
+}
+
+mutation cancelUserAccountDeletion($input: CancelUserAccountDeletionInput!) {
+  # Request just enough data so that the cache gets updated automatically
+  cancelUserAccountDeletion(input: $input) {
+    id
+    deletedAt
+  }
+}

--- a/packages/client/src/services/user.graphql
+++ b/packages/client/src/services/user.graphql
@@ -27,6 +27,7 @@ fragment Member on User {
 fragment Customer on User {
   ...User
   createdAt
+  scheduledForDeletionAt: deletedAt
   booksInStock
   booksSold
   booksReserved

--- a/packages/client/src/services/user.ts
+++ b/packages/client/src/services/user.ts
@@ -18,7 +18,7 @@ export function useDownloadUserData() {
       fetchPolicy: "network-only",
     });
     if (error) {
-      notifyError(t("auth.couldNotDownload"));
+      notifyError(t("manageUsers.editUser.downloadDataFailed"));
       return;
     }
 
@@ -27,9 +27,11 @@ export function useDownloadUserData() {
       mimeType: "application/json",
     });
     if (result !== true) {
-      notifyError(t("auth.couldNotDownload"));
+      console.error(result);
+      notifyError(t("manageUsers.editUser.downloadDataFailed"));
       return;
     }
+
     Notify.create({
       type: "positive",
       message: t("manageUsers.editUser.downloadDataSuccess"),

--- a/packages/client/src/services/user.ts
+++ b/packages/client/src/services/user.ts
@@ -1,0 +1,42 @@
+import { useApolloClient } from "@vue/apollo-composable";
+import { Notify, exportFile } from "quasar";
+import { useI18n } from "vue-i18n";
+import { notifyError } from "src/helpers/error-messages";
+import { GetUserDataDocument } from "src/services/user.graphql";
+
+export function useDownloadUserData() {
+  const { t } = useI18n();
+  const { resolveClient } = useApolloClient();
+
+  async function downloadData(userId: string) {
+    const client = resolveClient();
+    const { data, error } = await client.query({
+      query: GetUserDataDocument,
+      variables: {
+        userId,
+      },
+      fetchPolicy: "network-only",
+    });
+    if (error) {
+      notifyError(t("auth.couldNotDownload"));
+      return;
+    }
+
+    const stringifiedData = JSON.stringify(data.userData, null, 2);
+    const result = exportFile("userData.json", stringifiedData, {
+      mimeType: "application/json",
+    });
+    if (result !== true) {
+      notifyError(t("auth.couldNotDownload"));
+      return;
+    }
+    Notify.create({
+      type: "positive",
+      message: t("manageUsers.editUser.downloadDataSuccess"),
+    });
+  }
+
+  return {
+    downloadData,
+  };
+}

--- a/packages/server/prisma/migrations/20240515151448_add_deleted_at_to_user_table/migration.sql
+++ b/packages/server/prisma/migrations/20240515151448_add_deleted_at_to_user_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "deleted_at" TIMESTAMPTZ;

--- a/packages/server/prisma/migrations/20240516184649_add_on_delete_cascade_to_notification_and_event_relation/migration.sql
+++ b/packages/server/prisma/migrations/20240516184649_add_on_delete_cascade_to_notification_and_event_relation/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "Notification" DROP CONSTRAINT "Notification_event_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "Notification" ADD CONSTRAINT "Notification_event_id_fkey" FOREIGN KEY ("event_id") REFERENCES "Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -52,6 +52,7 @@ model User {
   emailVerified Boolean   @default(false)
   createdAt     DateTime  @default(now()) @map("created_at") @db.Timestamptz()
   updatedAt     DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
+  deletedAt     DateTime? @map("deleted_at") @db.Timestamptz()
 
   delegate String?
 
@@ -70,8 +71,10 @@ model User {
   createdBookRequests BookRequest[]   @relation("BookRequestMadeBy") // requests can also, also be made by operators
   deletedBookRequests BookRequest[]   @relation("BookRequestDeletedBy")
   ownedCarts          Cart[]          @relation("CartOwner")
+  ownedReceipts       Receipt[]       @relation("ReceiptOwner")
 
   // Operator/admin relations
+  memberships          LocationMember[]
   settledCopies        BookCopy[]       @relation("CopySettledBy")
   returnedBookCopies   BookCopy[]       @relation("CopyReturnedBy")
   reimbursedBookCopies BookCopy[]       @relation("CopyReimbursedBy")
@@ -84,8 +87,6 @@ model User {
   processedSales       Sale[]           @relation("CopySoldBy")
   salesInCreatedCarts  Sale[]           @relation("SaleInCartOpenedBy")
   createdCarts         Cart[]           @relation("CartOperator")
-  memberships          LocationMember[]
-  ownedReceipts        Receipt[]        @relation("ReceiptOwner")
   triggeredReceipts    Receipt[]        @relation("ReceiptCreator")
 }
 

--- a/packages/server/prisma/schema.prisma
+++ b/packages/server/prisma/schema.prisma
@@ -123,7 +123,7 @@ model Notification {
   userId  String    @map("user_id")
   user    User      @relation(fields: [userId], references: [id])
   eventId String    @map("event_id")
-  event   Event     @relation(fields: [eventId], references: [id])
+  event   Event     @relation(fields: [eventId], references: [id], onDelete: Cascade)
   readAt  DateTime? @map("read_at") @db.Timestamptz()
 
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz()

--- a/packages/server/src/modules/auth/auth.service.ts
+++ b/packages/server/src/modules/auth/auth.service.ts
@@ -91,7 +91,7 @@ export class AuthService {
     }
   }
 
-  async sendInviteLink(email: string, name: string, token: string) {
+  async sendInviteLink(email: string, invitedByName: string, token: string) {
     const url = `${this.rootConfig.clientUrl}/invite?token=${token}&email=${email}`;
 
     try {
@@ -99,7 +99,7 @@ export class AuthService {
         subject: "Invitation to join Il Mercatino del Libro",
         to: email,
         context: {
-          name,
+          invitedByName,
           url,
         },
         template: "invite-user",

--- a/packages/server/src/modules/auth/strategies/jwt.strategy.ts
+++ b/packages/server/src/modules/auth/strategies/jwt.strategy.ts
@@ -38,6 +38,9 @@ export class JwtStrategy extends PassportStrategy(Strategy, JWT_STRATEGY_NAME) {
         "User related to this token has not been found in our system",
       );
     }
+    if (user.deletedAt) {
+      throw new Error("User related to this token has been deleted");
+    }
 
     return user;
   }

--- a/packages/server/src/modules/mail/templates/invite-user.ejs
+++ b/packages/server/src/modules/mail/templates/invite-user.ejs
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
   <body>
     <p>
-      Hi! you have been invited by  <%= name %> to create an account on Il Mercatino del Libro.
+      Hi! you have been invited by <%= invitedByName %> to create an account on Il Mercatino del Libro.
     </p>
     <p>To proceed with registration <a href="<%= url %>">click here.</a></p>
 

--- a/packages/server/src/modules/user/user-account.input.ts
+++ b/packages/server/src/modules/user/user-account.input.ts
@@ -1,0 +1,19 @@
+import { ArgsType, Field, InputType } from "@nestjs/graphql";
+
+@ArgsType()
+export class GetUserDataArgs {
+  @Field()
+  userId!: string;
+}
+
+@InputType()
+export class DeleteUserAccountInput {
+  @Field()
+  userId!: string;
+}
+
+@InputType()
+export class CancelUserAccountDeletionInput {
+  @Field()
+  userId!: string;
+}

--- a/packages/server/src/modules/user/user-account.resolver.ts
+++ b/packages/server/src/modules/user/user-account.resolver.ts
@@ -1,0 +1,194 @@
+import { ForbiddenException } from "@nestjs/common";
+import { Args, Mutation, Query, Resolver } from "@nestjs/graphql";
+import { GraphQLJSONObject } from "graphql-scalars";
+import { User } from "src/@generated/user";
+import { AuthService } from "src/modules/auth/auth.service";
+import { CurrentUser } from "../auth/decorators/current-user.decorator";
+import { Input } from "../auth/decorators/input.decorator";
+import { PrismaService } from "../prisma/prisma.service";
+import {
+  CancelUserAccountDeletionInput,
+  DeleteUserAccountInput,
+  GetUserDataArgs,
+} from "./user-account.input";
+
+@Resolver(() => User)
+export class UserAccountResolver {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly authService: AuthService,
+  ) {}
+
+  @Query(() => GraphQLJSONObject, {
+    description: "Returns all the data of a user account.",
+  })
+  async userData(
+    @Args() { userId }: GetUserDataArgs,
+    @CurrentUser() actor: User,
+  ) {
+    if (userId !== actor.id) {
+      await this.authService.assertMembership({
+        userId: actor.id,
+        message: "You are not allowed to view user data of other users.",
+      });
+    }
+
+    const { deletedAt } = await this.prisma.user.findUniqueOrThrow({
+      where: {
+        id: userId,
+      },
+      select: {
+        deletedAt: true,
+      },
+    });
+    if (deletedAt && deletedAt <= new Date()) {
+      throw new ForbiddenException("This user account has been deleted.");
+    }
+
+    return await this.prisma.user.findUniqueOrThrow({
+      where: {
+        id: userId,
+      },
+      select: {
+        id: true,
+        firstname: true,
+        lastname: true,
+        dateOfBirth: true,
+        delegate: true,
+        email: true,
+        phoneNumber: true,
+        notes: true,
+        discount: true,
+        createdAt: true,
+        updatedAt: true,
+
+        bookCopies: {
+          include: {
+            book: true,
+            sales: {
+              where: {
+                refundedAt: null,
+              },
+              select: {
+                id: true,
+                purchasedAt: true,
+                iseeDiscountApplied: true,
+              },
+            },
+            problems: {
+              select: {
+                id: true,
+                type: true,
+                details: true,
+                solution: true,
+                createdAt: true,
+                resolvedAt: true,
+                bookCopyId: true,
+              },
+            },
+          },
+        },
+        purchases: {
+          include: {
+            bookCopy: {
+              include: {
+                book: true,
+              },
+            },
+          },
+        },
+        requestedBooks: {
+          select: {
+            id: true,
+            createdAt: true,
+            deletedAt: true,
+            book: true,
+          },
+        },
+        reservations: {
+          select: {
+            id: true,
+            createdAt: true,
+            expiresAt: true,
+            deletedAt: true,
+            book: true,
+          },
+        },
+        ownedReceipts: {
+          select: {
+            id: true,
+            type: true,
+            createdAt: true,
+            retailLocationId: true,
+          },
+        },
+      },
+    });
+  }
+
+  @Mutation(() => User, {
+    description:
+      "Schedule the deletion of a user account in 7 days. It can be canceled within this period by the operators.",
+  })
+  async deleteUserAccount(
+    @Input() { userId }: DeleteUserAccountInput,
+    @CurrentUser() actor: User,
+  ) {
+    if (userId !== actor.id) {
+      await this.authService.assertMembership({
+        userId: actor.id,
+        message: "You are not allowed to delete user accounts of other users.",
+      });
+    }
+
+    const HOUR = 60 * 60 * 1000;
+    return await this.prisma.user.update({
+      where: {
+        id: userId,
+      },
+      data: {
+        deletedAt: new Date(Date.now() + 7 * 24 * HOUR), // 7 days from now
+      },
+    });
+  }
+
+  @Mutation(() => User, {
+    description: "Cancel the scheduled deletion of a user account.",
+  })
+  async cancelUserAccountDeletion(
+    @Input() { userId }: CancelUserAccountDeletionInput,
+    @CurrentUser() operator: User,
+  ) {
+    await this.authService.assertMembership({
+      userId: operator.id,
+      message: "Only the operators can cancel the deletion of user accounts.",
+    });
+
+    const { deletedAt } = await this.prisma.user.findUniqueOrThrow({
+      where: {
+        id: userId,
+      },
+      select: {
+        deletedAt: true,
+      },
+    });
+    if (!deletedAt) {
+      throw new ForbiddenException(
+        "This user account is not scheduled for deletion.",
+      );
+    } else if (deletedAt <= new Date()) {
+      throw new ForbiddenException(
+        "This user account has already been deleted.",
+      );
+    }
+
+    return await this.prisma.user.update({
+      where: {
+        id: userId,
+      },
+      data: {
+        deletedAt: null,
+      },
+    });
+  }
+}

--- a/packages/server/src/modules/user/user.module.ts
+++ b/packages/server/src/modules/user/user.module.ts
@@ -1,12 +1,13 @@
 import { Module, forwardRef } from "@nestjs/common";
 import { AuthModule } from "src/modules/auth/auth.module";
+import { UserAccountResolver } from "src/modules/user/user-account.resolver";
 import { PrismaModule } from "../prisma/prisma.module";
 import { UserResolver } from "./user.resolver";
 import { UserService } from "./user.service";
 
 @Module({
   imports: [PrismaModule, forwardRef(() => AuthModule)],
-  providers: [UserResolver, UserService],
+  providers: [UserResolver, UserAccountResolver, UserService],
   exports: [UserService],
 })
 export class UserModule {}

--- a/packages/server/src/modules/user/user.resolver.ts
+++ b/packages/server/src/modules/user/user.resolver.ts
@@ -100,7 +100,7 @@ export class UserResolver {
                 ],
               },
             ]
-          : [{}]),
+          : []),
       ],
     };
 

--- a/packages/server/src/modules/user/user.service.ts
+++ b/packages/server/src/modules/user/user.service.ts
@@ -119,7 +119,13 @@ export class UserService {
     );
 
     // Avoid precise error messages to limit information leakage
-    if (!existingUser || !passwordIsCorrect || !existingUser.emailVerified) {
+    if (
+      !existingUser ||
+      !passwordIsCorrect ||
+      !existingUser.emailVerified ||
+      // The user account is scheduled for deletion or they somehow managed to guess the anonymized credentials after the deletion
+      existingUser.deletedAt
+    ) {
       throw new UnprocessableEntityException(
         "User either does not exist, password is incorrect or the email has not been verified yet.",
       );

--- a/packages/server/src/modules/user/user.service.ts
+++ b/packages/server/src/modules/user/user.service.ts
@@ -123,7 +123,10 @@ export class UserService {
       !existingUser ||
       !passwordIsCorrect ||
       !existingUser.emailVerified ||
-      // The user account is scheduled for deletion or they somehow managed to guess the anonymized credentials after the deletion
+      // The user account is scheduled for deletion. The user can only register again after the deletion date.
+      // Alternatively, the account can be restored so that the user can log in again.
+      // Side note: it's impossible to guess the credentials of a deleted account as the email is random
+      // and the password is not hashed, thus technically can't be compared against
       existingUser.deletedAt
     ) {
       throw new UnprocessableEntityException(


### PR DESCRIPTION
Adds some functionality:
- a button to download user data
- a button to schedule user account deletion
- a button to cancel the scheduled account deletion (operator-only)

to these places:
- for customer use: "my data" page
- for operator use: "edit user details" dialog

The user needs to send an email or give a call to cancel the account cancellation. The operators can do this easily in the UI. We could also add an account recovery page, but it's most likely not worth it as this would rather be a rare use case.