### PR TITLE
feat(server+client): wire and update users management

### DIFF
--- a/packages/client/src/components/edit-user-data-dialog.vue
+++ b/packages/client/src/components/edit-user-data-dialog.vue
@@ -18,7 +18,7 @@
         })
       "
     >
-      <q-card-section class="column gap-4 q-pb-xs q-pt-lg q-px-lg">
+      <q-card-section class="column gap-16 q-pb-xs q-pt-lg q-px-lg">
         <q-input
           v-for="(field, key) in formData"
           :key="key"

--- a/packages/client/src/components/manage-users/cart-dialog.vue
+++ b/packages/client/src/components/manage-users/cart-dialog.vue
@@ -24,7 +24,7 @@
             suffix="€"
           />
           <q-input
-            :model-value="totalBooksPrice"
+            :model-value="totalBooksPrice.toFixed(2)"
             :label="$t('manageUsers.cartDialog.total')"
             disable
             outlined
@@ -121,7 +121,11 @@
         <q-btn :label="$t('common.cancel')" flat @click="onDialogCancel()" />
         <q-btn
           :disable="cartBooks.length === 0"
-          :label="$t('manageUsers.cartDialog.sellBooks', [totalBooksPrice])"
+          :label="
+            $t('manageUsers.cartDialog.sellBooks', [
+              formatPrice(totalBooksPrice),
+            ])
+          "
           color="positive"
           @click="sellBooks()"
         />
@@ -449,7 +453,7 @@ function sellBooks() {
     componentProps: {
       title: t("manageUsers.cartDialog.confirm.title"),
       message: t("manageUsers.cartDialog.confirm.message", [
-        totalBooksPrice.value,
+        formatPrice(totalBooksPrice.value),
       ]),
       ok: t("manageUsers.cartDialog.confirm.sell"),
       cancel: t("common.cancel"),

--- a/packages/client/src/components/manage-users/edit-user-details-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-details-dialog.vue
@@ -1,4 +1,3 @@
-<!-- TODO: update this to include the missing fields -->
 <template>
   <q-dialog ref="dialogRef" persistent @hide="onDialogHide">
     <k-dialog-form-card
@@ -7,57 +6,104 @@
       @submit="
         onDialogOK(
           'id' in newUserData
-            ? { type: 'update', data: newUserData }
-            : { type: 'create', data: newUserData },
+            ? {
+                type: 'update',
+                data: { ...newUserData, dateOfBirth: Date.parse(birthDate) },
+              }
+            : {
+                type: 'create',
+                data: { ...newUserData, dateOfBirth: Date.parse(birthDate) },
+              },
         )
       "
       @cancel="onDialogCancel"
     >
       <!-- bottom-slots prop is used when there are no rules/hint/etc. to unify bottom padding with the ones that do have -->
-      <q-card-section class="column gap-4 no-wrap">
+      <!-- The listeners on @clear are to make the model an empty string instead of null when cleared -->
+      <q-card-section class="column gap-16 no-wrap q-pb-xs q-pt-lg q-px-lg">
         <q-input
           v-model="newUserData.firstname"
           :label="$t('manageUsers.fields.firstName')"
           :disable="scheduledForDeletion"
           :rules="[requiredRule]"
+          autocomplete="off"
+          bottom-slots
           clearable
           outlined
+          @clear="newUserData.firstname = ''"
         />
         <q-input
           v-model="newUserData.lastname"
           :label="$t('manageUsers.fields.lastName')"
           :disable="scheduledForDeletion"
           :rules="[requiredRule]"
+          autocomplete="off"
+          bottom-slots
           clearable
           outlined
+          @clear="newUserData.lastname = ''"
         />
+        <q-input
+          v-model="birthDate"
+          :label="t('auth.birthDate')"
+          :disable="scheduledForDeletion"
+          autocomplete="off"
+          bottom-slots
+          clearable
+          outlined
+          type="date"
+          @clear="birthDate = ''"
+        />
+        <q-input
+          v-model="newUserData.delegate"
+          :label="t('auth.nameOfDelegate')"
+          :disable="scheduledForDeletion"
+          :rules="[requireIfUnderage(birthDate)]"
+          autocomplete="off"
+          bottom-slots
+          clearable
+          outlined
+          @clear="newUserData.delegate = ''"
+        >
+          <template #append>
+            <q-icon :name="mdiInformationOutline">
+              <q-tooltip>
+                {{ t("auth.delegateLabel") }}
+              </q-tooltip>
+            </q-icon>
+          </template>
+        </q-input>
         <q-input
           v-model="newUserData.email"
           :label="$t('manageUsers.fields.email')"
           :disable="scheduledForDeletion"
           :rules="newUserData.email ? [emailRule] : undefined"
           autocomplete="off"
+          bottom-slots
           clearable
           outlined
+          @clear="newUserData.email = ''"
         />
         <q-input
           v-model="newUserData.phoneNumber"
           :disable="scheduledForDeletion"
           :label="$t('manageUsers.fields.phoneNumber')"
+          autocomplete="new-password"
           bottom-slots
           clearable
           mask="phone"
           outlined
+          @clear="newUserData.phoneNumber = ''"
         />
         <q-input
           v-model="newUserData.password"
           :disable="scheduledForDeletion"
           :label="$t('auth.password')"
-          :rules="newUserData.password ? [validatePasswordRule] : undefined"
+          :rules="newUserData.password ? [validatePasswordRule] : [() => true]"
           :type="hidePassword ? 'password' : 'text'"
           autocomplete="new-password"
-          outlined
           bottom-slots
+          outlined
         >
           <template #append>
             <q-icon
@@ -79,12 +125,12 @@
                     $t('auth.passwordDoNotMatch'),
                   ),
                 ]
-              : undefined
+              : [() => true]
           "
           :type="hideConfirm ? 'password' : 'text'"
           autocomplete="new-password"
-          outlined
           bottom-slots
+          outlined
         >
           <template #append>
             <q-icon
@@ -95,12 +141,16 @@
           </template>
         </q-input>
         <q-input
-          v-model="newUserData.notes"
+          v-model.string="newUserData.notes"
           :disable="scheduledForDeletion"
           :label="$t('manageUsers.editUser.notes')"
+          autocomplete="off"
+          bottom-slots
+          input-class="max-height-130"
           clearable
           outlined
-          bottom-slots
+          type="textarea"
+          @clear="newUserData.notes = ''"
         />
         <q-checkbox
           v-model="newUserData.discount"
@@ -113,7 +163,7 @@
       <template v-if="'id' in newUserData">
         <q-separator inset spaced />
 
-        <q-card-section class="column gap-8 no-wrap">
+        <q-card-section class="column gap-24 no-wrap q-pb-lg q-px-lg">
           <q-btn
             outline
             :icon="mdiDownload"
@@ -164,13 +214,17 @@ import {
   mdiDownload,
   mdiEye,
   mdiEyeOff,
+  mdiInformationOutline,
 } from "@quasar/extras/mdi-v7";
+import { formatDate } from "@vueuse/core";
 import { useDialogPluginComponent } from "quasar";
 import { ref } from "vue";
+import { useI18n } from "vue-i18n";
 import { RegisterUserPayload, UpdateUserPayload } from "src/@generated/graphql";
 import {
   emailRule,
   makeValueMatchRule,
+  requireIfUnderage,
   requiredRule,
   validatePasswordRule,
 } from "src/helpers/rules";
@@ -185,6 +239,8 @@ const { userData, scheduledForDeletion } = defineProps<{
   scheduledForDeletion?: boolean;
 }>();
 
+const { t } = useI18n();
+
 defineEmits(useDialogPluginComponent.emitsObject);
 
 const { dialogRef, onDialogCancel, onDialogHide, onDialogOK } =
@@ -194,6 +250,11 @@ const { hasAdminRole } = useAuthService();
 
 const { selectedLocation } = useRetailLocationService();
 
+const birthDate = ref(
+  userData?.dateOfBirth
+    ? formatDate(new Date(userData.dateOfBirth), "YYYY-MM-DD")
+    : "",
+);
 const newUserData = ref(
   userData
     ? ({ ...userData } satisfies UpdateUserPayload)
@@ -207,7 +268,8 @@ const newUserData = ref(
         password: "",
         passwordConfirmation: "",
         phoneNumber: "",
-        dateOfBirth: Date.now(),
+        dateOfBirth: Date.parse(birthDate.value),
+        delegate: "",
       } satisfies RegisterUserPayload),
 );
 const hidePassword = ref(true);

--- a/packages/client/src/components/manage-users/edit-user-details-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-details-dialog.vue
@@ -4,17 +4,13 @@
       :title="$t(`manageUsers.editUser.${userData ? 'title' : 'createUser'}`)"
       size="sm"
       @submit="
-        onDialogOK(
-          'id' in newUserData
-            ? {
-                type: 'update',
-                data: { ...newUserData, dateOfBirth: Date.parse(birthDate) },
-              }
-            : {
-                type: 'create',
-                data: { ...newUserData, dateOfBirth: Date.parse(birthDate) },
-              },
-        )
+        onDialogOK({
+          type: 'id' in newUserData ? 'update' : 'create',
+          data: {
+            ...newUserData,
+            dateOfBirth: Date.parse(birthDate),
+          } as RegisterUserPayload & UpdateUserPayload, // Otherwise TypesScript cannot properly narrow down the object's type
+        })
       "
       @cancel="onDialogCancel"
     >

--- a/packages/client/src/components/manage-users/edit-user-stockdata-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-stockdata-dialog.vue
@@ -123,7 +123,7 @@
             </template>
 
             <template #body-cell-utility="{ value }">
-              <q-td>
+              <q-td class="text-center">
                 <utility-chip :utility="value" />
               </q-td>
             </template>

--- a/packages/client/src/components/manage-users/retrieve-all-books-dialog.vue
+++ b/packages/client/src/components/manage-users/retrieve-all-books-dialog.vue
@@ -1,3 +1,4 @@
+<!-- TODO: add the logic to manage label printing and update to match the mock-ups -->
 <template>
   <q-dialog ref="dialogRef" @hide="onDialogHide">
     <k-dialog-card :title="$t('book.retrieveBooksDialog.title')">
@@ -6,32 +7,22 @@
       </q-card-section>
 
       <template #card-actions>
-        <q-btn
-          outline
-          no-wrap
-          :label="$t('book.retrieveBooksDialog.retrieveBooksBtn')"
-          @click="onDialogOK(false)"
-        />
-
         <q-space />
 
         <q-btn flat :label="$t('common.cancel')" @click="onDialogCancel" />
-        <q-btn no-wrap color="primary" @click="onDialogOK(true)">
-          <q-icon :name="mdiInformationOutline" class="q-mr-sm" size="18px">
-            <q-tooltip>
-              {{ $t("book.retrieveBooksDialog.tooltip") }}
-            </q-tooltip>
-          </q-icon>
 
-          {{ $t("book.retrieveBooksDialog.retrieveAndPrint") }}
-        </q-btn>
+        <q-btn
+          :label="$t('book.retrieveBooksDialog.retrieveBooksBtn')"
+          color="primary"
+          no-wrap
+          @click="onDialogOK(false)"
+        />
       </template>
     </k-dialog-card>
   </q-dialog>
 </template>
 
 <script setup lang="ts">
-import { mdiInformationOutline } from "@quasar/extras/mdi-v7";
 import { useDialogPluginComponent } from "quasar";
 import KDialogCard from "../k-dialog-card.vue";
 

--- a/packages/client/src/components/manage-users/round-badge.vue
+++ b/packages/client/src/components/manage-users/round-badge.vue
@@ -10,14 +10,20 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
-const props = defineProps<{ floatLeft?: boolean; floatLeftSquare?: boolean }>();
+const props = defineProps<{
+  floatLeft?: boolean;
+  floatLeftSquare?: boolean;
+  floatRight?: boolean;
+}>();
 
 const positionClass = computed(() =>
   props.floatLeft
     ? "top-left"
     : props.floatLeftSquare
-    ? "top-left--square"
-    : undefined,
+      ? "top-left--square"
+      : props.floatRight
+        ? "top-right"
+        : undefined,
 );
 </script>
 
@@ -33,5 +39,11 @@ const positionClass = computed(() =>
     position: absolute;
     top: -8px;
   }
+}
+
+.top-right {
+  position: absolute;
+  right: 0;
+  top: 0;
 }
 </style>

--- a/packages/client/src/components/manage-users/table-cell-with-tooltip.vue
+++ b/packages/client/src/components/manage-users/table-cell-with-tooltip.vue
@@ -1,9 +1,13 @@
 <template>
   <q-td>
-    <q-tooltip>
+    <span>
+      <q-tooltip>
+        {{ value }}
+      </q-tooltip>
       {{ value }}
-    </q-tooltip>
-    {{ value }}
+    </span>
+
+    <slot />
   </q-td>
 </template>
 

--- a/packages/client/src/css/utilities.scss
+++ b/packages/client/src/css/utilities.scss
@@ -127,7 +127,7 @@ $widths-list: 0, 24, 32, 160, 180, 200, 250, 260, 315, 360, 420, 560, 600, 700,
 }
 
 // heights
-$heights-list: 0, 24, 48, 52, 400, 600;
+$heights-list: 0, 24, 48, 52, 130, 400, 600;
 
 @each $height in $heights-list {
   .height-#{$height} {

--- a/packages/client/src/helpers/rules.ts
+++ b/packages/client/src/helpers/rules.ts
@@ -161,9 +161,9 @@ export const emptyRule: ValidationRule<string | null> = (value) =>
   !value?.length || value.length === 0 || t("validators.noDelegateForAdult");
 
 export const requireIfUnderage = (
-  birthDate: string | null,
+  birthDate?: string | null,
 ): ValidationRule<string | null> =>
-  birthDate === null || getAge(birthDate) >= 18 ? emptyRule : requiredRule;
+  !birthDate || getAge(birthDate) >= 18 ? emptyRule : requiredRule;
 
 // ---------- ---------- ----------
 // Next fields are not imported in other files but we need to leave these so in the future we can abstract these in a package

--- a/packages/client/src/i18n/en-US/auth.ts
+++ b/packages/client/src/i18n/en-US/auth.ts
@@ -33,6 +33,7 @@ export default {
   passwordDoNotMatch: "Passwords do not match",
   emailVerified:
     "Your email has been correctly verified, you can now login using your credentials",
+  emailNotVerified: "This user's account was not verified yet",
   backToLogin: "Back to login",
   backToLocations: "Back to locations",
   registeredSuccessfully: "Registration successful!",

--- a/packages/client/src/i18n/en-US/manage-users.ts
+++ b/packages/client/src/i18n/en-US/manage-users.ts
@@ -183,7 +183,7 @@ export default {
     emptyCart: "Empty the cart",
     autoEmptyDisclaimer:
       "Remember: you cannot keep the available books stuck in the cart for too long, therefore it will automatically be emptied in: {0}",
-    sellBooks: "Sell books ({0} €)",
+    sellBooks: "Sell books ({0})",
     totalBooks: "Total books to sell",
     discount: "ISEE/voluntary discount",
     total: "Total",

--- a/packages/client/src/i18n/en-US/salable-books.ts
+++ b/packages/client/src/i18n/en-US/salable-books.ts
@@ -15,4 +15,8 @@ export default {
     rejected: "Not accepted",
   },
   alreadySearched: "This book was already searched for",
+  bringBooksToRetailLocation:
+    "You can bring this book and the other ones marked as accepted to the Mercatino",
+  notAccepted:
+    "You cannot bring this book to the Mercatino because it is not in the list of the accepted books",
 };

--- a/packages/client/src/i18n/it/auth.ts
+++ b/packages/client/src/i18n/it/auth.ts
@@ -34,6 +34,7 @@ export default {
   passwordDoNotMatch: "Le password non corrispondono",
   emailVerified:
     "La tua email è stata verificata correttamente, ora puoi accedere utilizzando le tue credenziali",
+  emailNotVerified: "L’account di questo utente non è ancora stato verificato",
   backToLogin: "Torna al login",
   backToLocations: "Torna alle sedi",
   registeredSuccessfully: "Registrazione riuscita!",

--- a/packages/client/src/i18n/it/manage-users.ts
+++ b/packages/client/src/i18n/it/manage-users.ts
@@ -186,7 +186,7 @@ export default {
     emptyCart: "Svuota carrello",
     autoEmptyDisclaimer:
       "Ricorda: non puoi tenere i libri disponibili bloccati nel carrello per troppo tempo, perciò si svuoterà automaticamente tra: {0}",
-    sellBooks: "Vendi libri ({0} €)",
+    sellBooks: "Vendi libri ({0})",
     totalBooks: "Totale Libri da vendere",
     discount: "Sconto ISEE/volontario",
     total: "Totale",

--- a/packages/client/src/i18n/it/salable-books.ts
+++ b/packages/client/src/i18n/it/salable-books.ts
@@ -15,4 +15,8 @@ export default {
     rejected: "Non accettato",
   },
   alreadySearched: "Libro già cercato",
+  bringBooksToRetailLocation:
+    "Puoi portare questo libro e gli altri segnati come accettati al Mercatino",
+  notAccepted:
+    "Non puoi portare questo libro al Mercatino perché non è nella lista dei libri accettati",
 };

--- a/packages/client/src/layouts/authenticated-layout.vue
+++ b/packages/client/src/layouts/authenticated-layout.vue
@@ -31,7 +31,7 @@
                   {{ `${user.firstname} ${user.lastname}` }}
                 </span>
                 <span
-                  class="line-height-50 text-black-54 text-subtitle2 text-weight-regular"
+                  class="ellipsis full-width line-height-50 text-black-54 text-subtitle2 text-weight-regular"
                 >
                   {{ user.email }}
                 </span>
@@ -585,6 +585,7 @@ function openSettings() {
   // and using ellipses to truncate words we need to force that width to the content container too
   // Do not use just "width" otherwise you'l break "mini" mode
   max-width: calc(v-bind(DRAWER_WIDTH) * 1px);
+  width: 100%;
 }
 
 .drawer-item {

--- a/packages/client/src/layouts/authenticated-layout.vue
+++ b/packages/client/src/layouts/authenticated-layout.vue
@@ -590,7 +590,11 @@ function openSettings() {
 .drawer-item {
   border-radius: 4px;
   margin: 2px;
-  flex-grow: 1;
+  max-width: calc(
+    v-bind(DRAWER_WIDTH) * 1px - 4px
+  ); // Subtracting the 2px of margin on both left and right
+
+  width: 100%;
 }
 
 .q-btn--outline::before {

--- a/packages/client/src/pages/manage-users.vue
+++ b/packages/client/src/pages/manage-users.vue
@@ -70,8 +70,7 @@
               v-bind="
                 !props.row.emailVerified
                   ? {
-                      class: 'bg-blue-grey-1 text-black-54 cursor-not-allowed',
-                      noHover: true,
+                      class: 'bg-blue-grey-1 text-black-54',
                     }
                   : undefined
               "
@@ -79,7 +78,6 @@
               <template v-for="col in props.cols" :key="col.name">
                 <q-td v-if="col.name === 'edit'">
                   <q-btn
-                    :disable="!props.row.emailVerified"
                     :icon="mdiPencil"
                     color="primary"
                     flat
@@ -139,9 +137,7 @@
                   :clickable-when-zero="
                     alwaysClickableColsNames.includes(col.name)
                   "
-                  :disable="
-                    willBeDeleted(props.row) || !props.row.emailVerified
-                  "
+                  :disable="willBeDeleted(props.row)"
                   :secondary-value="
                     col.name === 'requested'
                       ? props.row.booksRequestedAndAvailable
@@ -169,9 +165,7 @@
                   :class="col.classes"
                 >
                   <q-btn
-                    :disable="
-                      willBeDeleted(props.row) || !props.row.emailVerified
-                    "
+                    :disable="willBeDeleted(props.row)"
                     :icon="mdiCart"
                     color="primary"
                     flat
@@ -190,7 +184,6 @@
 
                 <q-td v-else-if="col.name === 'receipts'" :class="col.classes">
                   <q-btn
-                    :disable="!props.row.emailVerified"
                     :icon="mdiReceiptText"
                     color="primary"
                     flat
@@ -204,19 +197,13 @@
                   <chip-button
                     :disable="
                       !selectedLocation.payOffEnabled ||
-                      willBeDeleted(props.row) ||
-                      !props.row.emailVerified
+                      willBeDeleted(props.row)
                     "
                     color="primary"
                     :label="$t('manageUsers.payOff')"
                     @click="openPayOff(props.row)"
                   >
-                    <q-tooltip
-                      v-if="
-                        !selectedLocation.payOffEnabled &&
-                        props.row.emailVerified
-                      "
-                    >
+                    <q-tooltip v-if="!selectedLocation.payOffEnabled">
                       {{ t("manageUsers.payOffDisabled") }}
                     </q-tooltip>
                   </chip-button>

--- a/packages/client/src/pages/manage-users.vue
+++ b/packages/client/src/pages/manage-users.vue
@@ -443,6 +443,8 @@ function openEdit({
   discount,
   notes,
   phoneNumber,
+  dateOfBirth,
+  delegate,
   scheduledForDeletionAt,
 }: CustomerFragment) {
   Dialog.create({
@@ -457,6 +459,8 @@ function openEdit({
         notes,
         phoneNumber,
         retailLocationId: selectedLocation.value.id,
+        dateOfBirth,
+        delegate,
       } satisfies UpdateUserPayload,
       scheduledForDeletion: !!scheduledForDeletionAt,
     },

--- a/packages/client/src/pages/manage-users.vue
+++ b/packages/client/src/pages/manage-users.vue
@@ -18,7 +18,7 @@
       </header-search-bar-filters>
 
       <q-card-section class="col no-wrap q-pa-none row">
-        <dialog-table
+        <q-table
           ref="tableRef"
           v-model:pagination="pagination"
           class="col"
@@ -228,7 +228,7 @@
               </template>
             </q-tr>
           </template>
-        </dialog-table>
+        </q-table>
       </q-card-section>
     </q-card>
   </q-page>
@@ -243,13 +243,12 @@ import {
   mdiReceiptText,
 } from "@quasar/extras/mdi-v7";
 import { Dialog, Notify, QTable, QTableColumn, QTableProps } from "quasar";
-import { Ref, computed, ref } from "vue";
+import { Ref, computed, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { UpdateUserPayload } from "src/@generated/graphql";
 import HeaderSearchBarFilters from "src/components/header-search-bar-filters.vue";
 import CartDialog from "src/components/manage-users/cart-dialog.vue";
 import ChipButton from "src/components/manage-users/chip-button.vue";
-import DialogTable from "src/components/manage-users/dialog-table.vue";
 import EditUserBooksMovementsDialog from "src/components/manage-users/edit-user-books-movements-dialog.vue";
 import EditUserDetailsDialog from "src/components/manage-users/edit-user-details-dialog.vue";
 import EditUserRequestedDialog from "src/components/manage-users/edit-user-requested-dialog.vue";
@@ -294,16 +293,18 @@ const pagination = ref({
   rowsNumber: rowsCount.value,
 });
 
-const { filterMethod, filterOptions, tableFilter } = useTableFilters(
-  "manageUsers.filters",
-);
+const { filterMethod, filterOptions, tableFilter, refetchFilterProxy } =
+  useTableFilters("manageUsers.filters");
+
+onMounted(() => {
+  tableRef.value.requestServerInteraction();
+});
 
 const onRequest: QTableProps["onRequest"] = async (requested) => {
   await fetchCustomers({
     page: requested.pagination.page,
     rowsPerPage: requested.pagination.rowsPerPage,
-    searchTerm: tableFilter.searchQuery,
-    // TODO: pass the filters to the server
+    filter: refetchFilterProxy.value,
   });
 
   pagination.value.rowsNumber = rowsCount.value;

--- a/packages/client/src/pages/reserve-books.vue
+++ b/packages/client/src/pages/reserve-books.vue
@@ -345,8 +345,6 @@ async function reserveBook(id: string) {
         e,
       ]),
     );
-  } finally {
-    swapView();
   }
 }
 

--- a/packages/client/src/pages/salable-books.vue
+++ b/packages/client/src/pages/salable-books.vue
@@ -96,6 +96,7 @@ import { Notify, QTableColumn } from "quasar";
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import DialogTable from "src/components/manage-users/dialog-table.vue";
+import { notifyError } from "src/helpers/error-messages";
 import { requiredRule, validISBN } from "src/helpers/rules";
 import { fetchBookByISBN } from "src/services/book";
 import { BookSummaryFragment } from "src/services/book.graphql";
@@ -210,13 +211,22 @@ async function searchBook() {
   const foundBook = await fetchBookByISBN(searchQuery.value);
   loading.value = false;
   if (foundBook) {
+    if (acceptedBooks.value.length === 0) {
+      Notify.create({
+        color: "positive",
+        message: t("salableBooks.bringBooksToRetailLocation"),
+      });
+    }
     acceptedBooks.value.push(foundBook);
   } else {
     rejectedBooks.value.push({
       isbnCode: searchQuery.value,
       status: AcceptanceStatus.REJECTED,
     });
+    notifyError(t("salableBooks.notAccepted"));
   }
+
+  searchQuery.value = "";
 }
 </script>
 

--- a/packages/client/src/services/user.graphql
+++ b/packages/client/src/services/user.graphql
@@ -34,7 +34,7 @@ fragment Member on User {
 }
 
 fragment Customer on User {
-  ...User
+  ...UpdatableUserInfo
   createdAt
   scheduledForDeletionAt: deletedAt
   booksInStock

--- a/packages/client/src/services/user.graphql
+++ b/packages/client/src/services/user.graphql
@@ -57,9 +57,9 @@ query getCustomers(
   $page: Int!
   $rowsPerPage: Int!
   $retailLocationId: String!
-  $searchTerm: String
+  $filter: UserQueryFilters
 ) {
-  users(page: $page, rowsPerPage: $rowsPerPage, searchTerm: $searchTerm) {
+  users(page: $page, rowsPerPage: $rowsPerPage, filter: $filter) {
     page
     rowsCount
     rows {

--- a/packages/client/src/services/user.graphql
+++ b/packages/client/src/services/user.graphql
@@ -36,6 +36,7 @@ fragment Member on User {
 fragment Customer on User {
   ...UpdatableUserInfo
   createdAt
+  emailVerified
   scheduledForDeletionAt: deletedAt
   booksInStock
   booksSold

--- a/packages/server/src/modules/auth/auth.args.ts
+++ b/packages/server/src/modules/auth/auth.args.ts
@@ -4,7 +4,11 @@ import { LocationBoundInput } from "src/modules/retail-location";
 
 @InputType()
 export class RegisterPayload extends IntersectionType(
-  PickType(User, ["email", "firstname", "lastname", "locale"], InputType),
+  PickType(
+    User,
+    ["email", "firstname", "lastname", "phoneNumber", "locale"],
+    InputType,
+  ),
 
   LocationBoundInput,
 ) {

--- a/packages/server/src/modules/auth/auth.resolver.ts
+++ b/packages/server/src/modules/auth/auth.resolver.ts
@@ -101,11 +101,18 @@ export class AuthResolver {
         "Confirmation password doesn't match with provided password!",
       );
     }
-    await this.userService.createUser(
+
+    const newUser = await this.userService.createUser(
       omit(registerPayload, ["passwordConfirmation", "retailLocationId"]),
       true,
     );
-    // TODO: create the location membership with the operator role
+    await this.prisma.locationMember.create({
+      data: {
+        role: "OPERATOR",
+        retailLocationId: registerPayload.retailLocationId,
+        userId: newUser.id,
+      },
+    });
   }
 
   @Public()

--- a/packages/server/src/modules/user/user.args.ts
+++ b/packages/server/src/modules/user/user.args.ts
@@ -16,6 +16,24 @@ import {
   LocationBoundQueryArgs,
 } from "src/modules/retail-location";
 
+@InputType()
+export class UserQueryFilters {
+  @Field(() => String, { nullable: true })
+  search?: string;
+
+  @Field(() => Boolean, { nullable: true })
+  withAvailable?: boolean;
+
+  @Field(() => Boolean, { nullable: true })
+  withRequested?: boolean;
+
+  @Field(() => Boolean, { nullable: true })
+  withPurchased?: boolean;
+
+  @Field(() => Boolean, { nullable: true })
+  withSold?: boolean;
+}
+
 @ArgsType()
 export class UsersQueryArgs {
   @Field(() => Int)
@@ -24,10 +42,8 @@ export class UsersQueryArgs {
   @Field(() => Int, { defaultValue: 100 })
   rowsPerPage!: number;
 
-  @Field(() => String, { nullable: true })
-  searchTerm?: string;
-
-  // TODO: Add filters (with available, with requested, with purchased, with sold)
+  @Field(() => UserQueryFilters, { nullable: true })
+  filter?: UserQueryFilters;
 }
 
 @ObjectType()

--- a/packages/server/src/modules/user/user.resolver.ts
+++ b/packages/server/src/modules/user/user.resolver.ts
@@ -68,7 +68,6 @@ export class UserResolver {
     };
 
     const where: Prisma.UserWhereInput = {
-      emailVerified: true,
       AND: [
         // Also include accounts that are scheduled for deletion so that they can be restored while they are still within the grace period
         {


### PR DESCRIPTION
## What it does
This feature implements:
- the server logic (and wiring with the frontend UI) of the filters for the "Manage Users"
- the update of the local cache after new settings are applied by an Admin for a Retail Location
- the visualization of users with unverified e-mails in the list
- some minor UI fixes

## How to test it
- Login as Operator or Admin
- Navigate to `/users-management` and verify the presence of unverified users
- As an Admin, change the retail location's settings and click "save", verify that the settings update the UI accordingly (in particular the setting to enable/disable pay-offs)