### PR TITLE
fix(client+server): show only books with copies

### DIFF
--- a/packages/client/src/services/book.graphql
+++ b/packages/client/src/services/book.graphql
@@ -42,7 +42,14 @@ query getBooks(
   }
 }
 
-query getBooksWithAvailableCopies(
+fragment BookWithCopiesInStock on Book {
+  ...BookSummary
+  copies {
+    ...BookCopyDetails
+  }
+}
+
+query getBooksWithCopiesInStock(
   $retailLocationId: String!
   $page: Int!
   $rows: Int!
@@ -53,10 +60,11 @@ query getBooksWithAvailableCopies(
     page: $page
     rows: $rows
     filter: $filter
+    copiesInStock: true
   ) {
     page
     rows {
-      ...BookWithAvailableCopies
+      ...BookWithCopiesInStock
     }
     rowsCount
   }

--- a/packages/server/src/modules/book/book.args.ts
+++ b/packages/server/src/modules/book/book.args.ts
@@ -33,6 +33,9 @@ export class BookQueryArgs extends LocationBoundQueryArgs {
 
   @Field(() => BookQueryFilter, { nullable: true })
   filter?: BookQueryFilter;
+
+  @Field(() => Boolean, { nullable: true })
+  copiesInStock?: boolean;
 }
 
 @ObjectType()

--- a/packages/server/src/modules/book/book.resolver.ts
+++ b/packages/server/src/modules/book/book.resolver.ts
@@ -31,6 +31,7 @@ export class BookResolver {
       rows: rowsPerPage = 100,
       filter = {},
       retailLocationId,
+      copiesInStock,
     }: BookQueryArgs,
   ) {
     // TODO: Use Prisma full-text search
@@ -47,6 +48,14 @@ export class BookResolver {
 
     const where: Prisma.BookWhereInput = {
       retailLocationId,
+
+      ...(copiesInStock
+        ? {
+            copies: {
+              some: {},
+            },
+          }
+        : {}),
 
       AND: [
         // Filter for availability


### PR DESCRIPTION
## What it does
This fixes the view of the Warehouse page, from #51, as the fix in #54 wasn't correct.

## How to test it
Retrieve some book copies, go to Warehouse, report problems on every copy of the book and verify that the book stays in view