### PR TITLE
feat(server): minimal seeding

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -243,14 +243,41 @@ After this step is done, all the pieces of the puzzle are in their place and the
 Another note: for the moment I decided not to connect Schools to a retailLocation, even if the school code already includes the province, thus the retailLocationId.
 This is because at the moment there are no requirements involving such a thing and in this way schools can be still viewed from other retailLocations.
 
-## The default Admin user
+## Other useful commands
 
-Run the `pnpm add-admin` from a terminal within the `/packages/server` folder of the project to set up or repair the Admin user for both retail locations.
+**Important:** These commands can only be run after the project is fully set up, in other words if the following 2 commands have been run from a terminal:
+
+```bash
+# inside the root folder of the project (not inside any of its subdirectories)
+pnpm i
+```
+
+and
+
+```bash
+# inside the /packages/server folder (not inside any of its subdirectories)
+pnpm build
+```
+
+_Navigating to the `/packages/server` folder inside a terminal at the root folder can be done via the `cd .\packages\server` command_
+
+### Creating or repairing the default Admin user
+
+Run the `pnpm add-admin` command from a terminal within the `/packages/server` folder of the project to set up or repair the Admin user for both retail locations.
 
 When running the command:
 
 - if the default Admin doesn't exist, it and its relative permissions are automatically added inside the database;
 - otherwise, the permissions for the existing Admin are checked and restored automatically if any are missing.
+
+## Seeding users
+
+Run the `pnpm seed-users-with-books` command from a terminal within the `/packages/server` folder of the project to seed the database with some test users.
+
+Available options:
+
+- `-c, --clear`: clears all previously seeded users and their data from the database; **in alternative, the command `pnpm seed-users-with-books:clear` can also be used to perform the same task**.
+- `-r, --random [number]`: specify how much above the base of 10 the range of randomly created copies per user can go; the command only accepts integer numbers greater than zero.
 
 ## Social login
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -196,6 +196,8 @@ pnpm build
 
 If both installation and build were successful you can continue with the next steps. The build step is necessary because it generates the files used to run the commands inside the terminal.
 
+**N.B.** Just to be sure that the logos of the retail locations are correctly displayed, regardless of the way the software is installed, please **copy them over** from their respective folders inside the `packages/client/public/location/${locationCode}/logo/logo-${location}.svg` folder and into `packages/server/storage/location/${locationCode}/logo/` folder.
+
 ### 2. Import Books
 
 The first thing to do here is to import the books dataset from the [ministry website](https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Adozioni%20libri%20di%20testo) and place it into `./storage/tmp`. The file name should be `ALTEMILIAROMAGNA.csv`, so the location of the file, with respect to where the CLI command to run the server is executed, should be `./storage/tmp/ALTEMILIAROMAGNA.csv`.

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -243,6 +243,15 @@ After this step is done, all the pieces of the puzzle are in their place and the
 Another note: for the moment I decided not to connect Schools to a retailLocation, even if the school code already includes the province, thus the retailLocationId.
 This is because at the moment there are no requirements involving such a thing and in this way schools can be still viewed from other retailLocations.
 
+## The default Admin user
+
+Run the `pnpm add-admin` from a terminal within the `/packages/server` folder of the project to set up or repair the Admin user for both retail locations.
+
+When running the command:
+
+- if the default Admin doesn't exist, it and its relative permissions are automatically added inside the database;
+- otherwise, the permissions for the existing Admin are checked and restored automatically if any are missing.
+
 ## Social login
 
 We use the `passport` library to handle social login. See [the auth module](./src/modules/auth) for implementation details. All providers are optional and will be enabled only if their related environment variables are set. If you configure a provider, make sure to also enable it in the client app. See the [client README](../client/README.md#social-login) for more information.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,6 +14,7 @@
     "clean": "rimraf dist && rimraf client-dist && rimraf src/@generated",
     "prebuild": "pnpm clean && pnpm generate",
     "build": "nest build",
+    "add-admin": "node dist/src/commander add-admin",
     "import:books": "node dist/src/commander import",
     "import:schools": "node dist/src/commander import --school",
     "lint": "eslint --ext .js,.ts ./ --fix --report-unused-disable-directives",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,6 +17,8 @@
     "add-admin": "node dist/src/commander add-admin",
     "import:books": "node dist/src/commander import",
     "import:schools": "node dist/src/commander import --school",
+    "seed-users-with-books": "node dist/src/commander seed-users-with-books",
+    "seed-users-with-books:clear": "node dist/src/commander seed-users-with-books --clear",
     "lint": "eslint --ext .js,.ts ./ --fix --report-unused-disable-directives",
     "format": "prettier --write \"**/*.{js,ts,graphql,md,json,yml,prisma}\" --ignore-path .gitignore",
     "start": "nest start",

--- a/packages/server/src/modules/book-copy/book-copy.resolver.ts
+++ b/packages/server/src/modules/book-copy/book-copy.resolver.ts
@@ -591,6 +591,7 @@ export class BookCopyResolver {
         prisma,
         [bookCopy.bookId],
         retailLocationId,
+        true,
       );
 
       const newBookCopyCode = codes[0];

--- a/packages/server/src/modules/book-copy/book-copy.resolver.ts
+++ b/packages/server/src/modules/book-copy/book-copy.resolver.ts
@@ -591,7 +591,6 @@ export class BookCopyResolver {
         prisma,
         [bookCopy.bookId],
         retailLocationId,
-        true,
       );
 
       const newBookCopyCode = codes[0];

--- a/packages/server/src/modules/book-copy/book-copy.service.ts
+++ b/packages/server/src/modules/book-copy/book-copy.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from "@nestjs/common";
-import { maxBy } from "lodash";
 import { PrismaTransactionClient } from "../../helpers/prisma";
 
 @Injectable()
@@ -8,7 +7,6 @@ export class BookCopyService {
     prisma: PrismaTransactionClient,
     bookIds: string[],
     retailLocationId: string,
-    bypassFragmentation?: boolean,
   ) {
     const { warehouseMaxBlockSize } =
       await prisma.retailLocation.findUniqueOrThrow({
@@ -16,122 +14,124 @@ export class BookCopyService {
           id: retailLocationId,
         },
       });
+    const useFragmentation = bookIds.length > warehouseMaxBlockSize;
 
-    /**
-     * Record containing each block and its copies
-     * ```ts
-     * {
-     *   [blockCode: string]: copyCodes: number[]
-     * }
-     * ```
-     */
-    const blocks: Record<string, number[]> = {};
-
-    /** All copy codes already present in stock (not sold, not returned) */
-    const presentCopyCodes = await prisma.bookCopy.findMany({
-      select: {
-        code: true,
-      },
-      where: {
-        // Only book copies belonging to current retailLocation are considered
-        book: {
-          retailLocationId,
-        },
-        // Only book copies that were not sold must be considered. To control this, one these two conditions must be met:
-        // 1 - all existing sale records related to that copy must have been refunded -> means the book copy status is currently not sold
-        // 2 - or that book copy does not have any sale record at all
-        OR: [
-          {
-            sales: {
-              every: {
-                refundedAt: {
-                  not: null,
-                },
-              },
-            },
-          },
-          {
-            sales: {
-              none: {},
-            },
-          },
-        ],
-        // Book copy was not returned to the original owner during settlement operation
-        returnedAt: null,
-        // All books outside these three conditions, even if they have problems, must be considered present for the purposes of this function
-      },
-      orderBy: {
-        code: "asc",
-      },
-    });
-
-    for (const { code } of presentCopyCodes) {
-      blocks[code.split("/")[1]] = [
-        ...(blocks[code.split("/")[1]] ?? []),
-        parseInt(code.split("/")[0]),
-      ];
-    }
-
-    const firstFreeBlock =
-      parseInt(
-        maxBy(Object.entries(blocks), ([block]) => parseInt(block))?.[0] ??
-          "-1",
-      ) + 1; // One more than the highest block code found
-
-    if (!bypassFragmentation && bookIds.length <= warehouseMaxBlockSize) {
-      // No fragmentation, all books get added to a new block
-      return this.#fillFromFirstFreeBlock(
-        firstFreeBlock,
-        warehouseMaxBlockSize,
-        bookIds,
-      );
-    }
-
-    /** Array corresponding to a full block */
-    const fullBlockCodes = Array(warehouseMaxBlockSize)
-      .fill(null)
-      .map((_, index) => index);
-
-    const codesFromBlocksToFill: string[] = [];
-
-    for (const [block, codes] of Object.entries(blocks)) {
-      if (codes.length < warehouseMaxBlockSize) {
-        codesFromBlocksToFill.push(
-          ...fullBlockCodes
-            .filter((code) => !codes.includes(code))
-            .map((code) => {
-              return this.#formattedCode(code, block);
-            }),
-        );
-      }
-    }
-
-    return [
-      ...codesFromBlocksToFill.slice(0, bookIds.length),
-      ...(codesFromBlocksToFill.length < bookIds.length
-        ? this.#fillFromFirstFreeBlock(
-            firstFreeBlock,
-            warehouseMaxBlockSize,
-            bookIds.slice(codesFromBlocksToFill.length),
-          )
-        : []),
-    ];
-  }
-
-  #fillFromFirstFreeBlock(
-    firstFreeBlock: number,
-    warehouseMaxBlockSize: number,
-    array: string[],
-  ) {
-    return array.map((_, index) =>
-      this.#formattedCode(
-        index % warehouseMaxBlockSize,
-        (firstFreeBlock + Math.trunc(index / warehouseMaxBlockSize)).toString(),
-      ),
+    return this.#getMaxAssignedNumber(
+      prisma,
+      retailLocationId,
+      bookIds.length,
+      useFragmentation,
     );
   }
 
-  #formattedCode(code: number, block: string) {
-    return `${code.toString().padStart(3, "0")}/${block.padStart(3, "0")}`;
+  async #getMaxAssignedNumber(
+    prisma: PrismaTransactionClient,
+    retailLocationId: string,
+    numberOfCodesToGenerate: number,
+    useFragmentation = false,
+  ) {
+    const currentlyAssignedCodes = (
+      await prisma.bookCopy.findMany({
+        select: {
+          code: true,
+        },
+        where: {
+          // Only book copies belonging to current retailLocation are considered
+          book: {
+            retailLocationId,
+          },
+          // Only book copies that were not sold must be considered. To control this, one these two conditions must be met:
+          // 1 - all existing sale records related to that copy must have been refunded -> means the book copy status is currently not sold
+          // 2 - or that book copy does not have any sale record at all
+          OR: [
+            {
+              sales: {
+                every: {
+                  refundedAt: {
+                    not: null,
+                  },
+                },
+              },
+            },
+            {
+              sales: { none: {} },
+            },
+          ],
+          // Book copy was not returned to the original owner during settlement operation
+          returnedBy: {
+            is: null,
+          },
+          // All books outside these three conditions, even if they have problems, must be considered present for the purposes of this function
+        },
+        orderBy: {
+          code: "asc",
+        },
+      })
+    ).map(({ code }) => parseInt(code.split("/")[0]));
+
+    if (currentlyAssignedCodes.length === 0 || !useFragmentation) {
+      // When registering new books at the end of the current codes, we must consider also books that have been sold/returned.
+      const storedMaxCode = await prisma.bookCopy.aggregate({
+        _max: {
+          code: true,
+        },
+        where: {
+          // Only copies belonging to current retailLocation are considered
+          book: {
+            retailLocationId,
+          },
+        },
+      });
+
+      const currentMaxAssignedNumber = storedMaxCode._max.code
+        ? storedMaxCode._max.code
+        : "0000/000";
+      let shelfCode = parseInt(currentMaxAssignedNumber.split("/")[0]);
+      const generatedCodes: string[] = [];
+      for (let i = 0; i < numberOfCodesToGenerate; i++) {
+        shelfCode++;
+        generatedCodes.push(`${shelfCode}`.padStart(4, "0") + "/001");
+      }
+
+      return generatedCodes;
+    }
+
+    const foundSlots: string[] = [];
+    for (let i = 0; foundSlots.length < numberOfCodesToGenerate; i++) {
+      if (!currentlyAssignedCodes.includes(i)) {
+        foundSlots.push(`${i}`.padStart(4, "0"));
+        break;
+      }
+    }
+
+    const maxCodesUsedForSlots = await Promise.all(
+      foundSlots.map((slotShelfCode) =>
+        prisma.bookCopy.aggregate({
+          _max: {
+            code: true,
+          },
+          where: {
+            // Only copies belonging to current retailLocation are considered
+            book: {
+              retailLocationId,
+            },
+            code: {
+              startsWith: slotShelfCode + "/",
+            },
+          },
+        }),
+      ),
+    );
+
+    return maxCodesUsedForSlots.map((prismaCode, index) => {
+      if (!prismaCode._max.code) {
+        return foundSlots[index] + "/001";
+      }
+
+      const codeParts = prismaCode._max.code.split("/");
+      return `${codeParts[0]}/${(parseInt(codeParts[1]) + 1)
+        .toString()
+        .padStart(3, "0")}`;
+    });
   }
 }

--- a/packages/server/src/modules/book-copy/book-copy.service.ts
+++ b/packages/server/src/modules/book-copy/book-copy.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from "@nestjs/common";
+import { maxBy } from "lodash";
 import { PrismaTransactionClient } from "../../helpers/prisma";
 
 @Injectable()
@@ -7,124 +8,130 @@ export class BookCopyService {
     prisma: PrismaTransactionClient,
     bookIds: string[],
     retailLocationId: string,
+    bypassFragmentation?: boolean,
   ) {
     const { warehouseMaxBlockSize } =
-      await prisma.retailLocation.findFirstOrThrow({
+      await prisma.retailLocation.findUniqueOrThrow({
         where: {
           id: retailLocationId,
         },
       });
-    const useFragmentation = bookIds.length > warehouseMaxBlockSize;
 
-    return this.#getMaxAssignedNumber(
-      prisma,
-      retailLocationId,
-      bookIds.length,
-      useFragmentation,
-    );
-  }
+    /**
+     * Record containing each block and its copies
+     * ```ts
+     * {
+     *   [blockCode: string]: copyCodes: number[]
+     * }
+     * ```
+     */
+    const blocks: Record<string, number[]> = {};
 
-  async #getMaxAssignedNumber(
-    prisma: PrismaTransactionClient,
-    retailLocationId: string,
-    numberOfCodesToGenerate: number,
-    useFragmentation = false,
-  ) {
-    const currentlyAssignedCodes = (
-      await prisma.bookCopy.findMany({
-        select: {
-          code: true,
+    /** All copy codes already present in stock (not sold, not returned) */
+    const presentCopyCodes = await prisma.bookCopy.findMany({
+      select: {
+        code: true,
+      },
+      where: {
+        // Only book copies belonging to current retailLocation are considered
+        book: {
+          retailLocationId,
         },
-        where: {
-          // Only book copies belonging to current retailLocation are considered
-          book: {
-            retailLocationId,
-          },
-          // Only book copies that were not sold must be considered. To control this, one these two conditions must be met:
-          // 1 - all existing sale records related to that copy must have been refunded -> means the book copy status is currently not sold
-          // 2 - or that book copy does not have any sale record at all
-          sales: {
-            every: {
-              refundedAt: {
-                not: null,
+        // Only book copies that were not sold must be considered. To control this, one these two conditions must be met:
+        // 1 - all existing sale records related to that copy must have been refunded -> means the book copy status is currently not sold
+        // 2 - or that book copy does not have any sale record at all
+        OR: [
+          {
+            sales: {
+              every: {
+                refundedAt: {
+                  not: null,
+                },
               },
             },
           },
-          // Book copy was not returned to the original owner during settlement operation
-          returnedBy: {
-            is: null,
-          },
-          // All books outside these three conditions, even if they have problems, must be considered present for the purposes of this function
-        },
-        orderBy: {
-          code: "asc",
-        },
-      })
-    ).map(({ code }) => parseInt(code.split("/")[0]));
-
-    if (currentlyAssignedCodes.length === 0 || !useFragmentation) {
-      // When registering new books at the end of the current codes, we must consider also books that have been sold/returned.
-      const storedMaxCode = await prisma.bookCopy.aggregate({
-        _max: {
-          code: true,
-        },
-        where: {
-          // Only copies belonging to current retailLocation are considered
-          book: {
-            retailLocationId,
-          },
-        },
-      });
-
-      const currentMaxAssignedNumber = storedMaxCode._max.code
-        ? storedMaxCode._max.code
-        : "0000/000";
-      let shelfCode = parseInt(currentMaxAssignedNumber.split("/")[0]);
-      const generatedCodes: string[] = [];
-      for (let i = 0; i < numberOfCodesToGenerate; i++) {
-        shelfCode++;
-        generatedCodes.push(`${shelfCode}`.padStart(4, "0") + "/001");
-      }
-
-      return generatedCodes;
-    }
-
-    const foundSlots: string[] = [];
-    for (let i = 0; foundSlots.length < numberOfCodesToGenerate; i++) {
-      if (!currentlyAssignedCodes.includes(i)) {
-        foundSlots.push(`${i}`.padStart(4, "0"));
-        break;
-      }
-    }
-
-    const maxCodesUsedForSlots = await Promise.all(
-      foundSlots.map((slotShelfCode) =>
-        prisma.bookCopy.aggregate({
-          _max: {
-            code: true,
-          },
-          where: {
-            // Only copies belonging to current retailLocation are considered
-            book: {
-              retailLocationId,
-            },
-            code: {
-              startsWith: slotShelfCode + "/",
+          {
+            sales: {
+              none: {},
             },
           },
-        }),
+        ],
+        // Book copy was not returned to the original owner during settlement operation
+        returnedAt: null,
+        // All books outside these three conditions, even if they have problems, must be considered present for the purposes of this function
+      },
+      orderBy: {
+        code: "asc",
+      },
+    });
+
+    for (const { code } of presentCopyCodes) {
+      blocks[code.split("/")[1]] = [
+        ...(blocks[code.split("/")[1]] ?? []),
+        parseInt(code.split("/")[0]),
+      ];
+    }
+
+    const firstFreeBlock =
+      parseInt(
+        maxBy(Object.entries(blocks), ([block]) => parseInt(block))?.[0] ??
+          "-1",
+      ) + 1; // One more than the highest block code found
+
+    if (!bypassFragmentation && bookIds.length <= warehouseMaxBlockSize) {
+      // No fragmentation, all books get added to a new block
+      return this.#fillFromFirstFreeBlock(
+        firstFreeBlock,
+        warehouseMaxBlockSize,
+        bookIds,
+      );
+    }
+
+    /** Array corresponding to a full block */
+    const fullBlockCodes = Array(warehouseMaxBlockSize)
+      .fill(null)
+      .map((_, index) => index);
+
+    const codesFromBlocksToFill: string[] = [];
+
+    for (const [block, codes] of Object.entries(blocks)) {
+      if (codes.length < warehouseMaxBlockSize) {
+        codesFromBlocksToFill.push(
+          ...fullBlockCodes
+            .filter((code) => !codes.includes(code))
+            .map((code) => {
+              return this.#formattedCode(code, block);
+            }),
+        );
+      }
+    }
+
+    return [
+      ...codesFromBlocksToFill.slice(0, bookIds.length),
+      ...(codesFromBlocksToFill.length < bookIds.length
+        ? this.#fillFromFirstFreeBlock(
+            firstFreeBlock,
+            warehouseMaxBlockSize,
+            bookIds.slice(codesFromBlocksToFill.length),
+          )
+        : []),
+    ];
+  }
+
+  #fillFromFirstFreeBlock(
+    firstFreeBlock: number,
+    warehouseMaxBlockSize: number,
+    array: string[],
+  ) {
+    return array.map((_, index) =>
+      this.#formattedCode(
+        index % warehouseMaxBlockSize,
+        (firstFreeBlock + Math.trunc(index / warehouseMaxBlockSize)).toString(),
       ),
     );
+  }
 
-    return maxCodesUsedForSlots.map((prismaCode, index) => {
-      if (!prismaCode._max.code) {
-        return foundSlots[index] + "/001";
-      }
-
-      const codeParts = prismaCode._max.code.split("/");
-      return `${codeParts[0]}/${(parseInt(codeParts[1]) + 1)
-        .toString()
-        .padStart(3, "0")}`;
-    });
+  #formattedCode(code: number, block: string) {
+    return `${code.toString().padStart(3, "0")}/${block.padStart(3, "0")}`;
   }
 }

--- a/packages/server/src/modules/reservation/reservation.resolver.ts
+++ b/packages/server/src/modules/reservation/reservation.resolver.ts
@@ -55,7 +55,9 @@ export class ReservationResolver {
           },
           {
             sale: {
-              refundedAt: null,
+              refundedAt: {
+                not: null,
+              },
             },
           },
         ],

--- a/packages/server/src/modules/user/add-admin-user.command.ts
+++ b/packages/server/src/modules/user/add-admin-user.command.ts
@@ -1,0 +1,99 @@
+import { Logger } from "@nestjs/common";
+import { User } from "@prisma/client";
+import { Command, CommandRunner } from "nest-commander";
+import { PrismaService } from "src/modules/prisma/prisma.service";
+import retailLocations from "test/fixtures/retail-locations";
+
+const adminData: Pick<User, "email" | "password" | "firstname" | "lastname"> = {
+  email: "info@ilmercatinodellibro.com",
+  password:
+    "$argon2id$v=19$m=65536,t=3,p=4$Ae3q36sm3zzXuh9IOFigaA$orXmayUt1IKLZC8TXGPXdb2osyBzZspVToEmeMYgvU8",
+  firstname: "Il Mercatino de Libro",
+  lastname: "",
+};
+
+@Command({
+  name: "add-admin",
+  description:
+    "Adds the default admin user inside the DB if not already present.",
+})
+export class AddAdminUserCommand extends CommandRunner {
+  private readonly logger = new Logger(AddAdminUserCommand.name);
+  constructor(private readonly prisma: PrismaService) {
+    super();
+  }
+
+  async run(_: string[]): Promise<void> {
+    const currentAdmin = await this.prisma.user.findUnique({
+      where: {
+        ...adminData,
+      },
+      include: {
+        memberships: true,
+      },
+    });
+
+    if (currentAdmin) {
+      this.logger.log("The admin user already exists");
+
+      const membershipsToAdd = retailLocations.filter(
+        ({ id }) =>
+          !currentAdmin.memberships.find(
+            ({ retailLocationId, role }) =>
+              retailLocationId === id && role === "ADMIN",
+          ),
+      );
+
+      if (membershipsToAdd.length === 0) {
+        this.logger.log("The roles and permissions are already correctly set");
+        return;
+      }
+
+      this.logger.log(
+        "The current admin doesn't have correct permissions.\nRestoring roles and permissions....",
+      );
+
+      await this.prisma.locationMember.deleteMany({
+        where: {
+          userId: currentAdmin.id,
+          role: {
+            not: "ADMIN",
+          },
+        },
+      });
+      await this.prisma.locationMember.createMany({
+        data: membershipsToAdd.map(({ id }) => ({
+          retailLocationId: id,
+          role: "ADMIN",
+          userId: currentAdmin.id,
+        })),
+      });
+
+      this.logger.log("Memberships added successfully");
+      return;
+    }
+
+    this.logger.log("Creating the new admin...");
+    try {
+      await this.prisma.user.create({
+        data: {
+          ...adminData,
+          emailVerified: true,
+          memberships: {
+            create: retailLocations.map(({ id }) => ({
+              retailLocationId: id,
+              role: "ADMIN",
+            })),
+          },
+        },
+      });
+
+      this.logger.log("Successfully added the admin user to the database");
+    } catch (error) {
+      this.logger.error(
+        "Something went wrong during the creation of the admin. Try again",
+        error,
+      );
+    }
+  }
+}

--- a/packages/server/src/modules/user/add-admin-user.command.ts
+++ b/packages/server/src/modules/user/add-admin-user.command.ts
@@ -8,7 +8,7 @@ const adminData: Pick<User, "email" | "password" | "firstname" | "lastname"> = {
   email: "info@ilmercatinodellibro.com",
   password:
     "$argon2id$v=19$m=65536,t=3,p=4$Ae3q36sm3zzXuh9IOFigaA$orXmayUt1IKLZC8TXGPXdb2osyBzZspVToEmeMYgvU8",
-  firstname: "Il Mercatino de Libro",
+  firstname: "Il Mercatino del Libro",
   lastname: "",
 };
 

--- a/packages/server/src/modules/user/seed-users-with-books.command.ts
+++ b/packages/server/src/modules/user/seed-users-with-books.command.ts
@@ -187,6 +187,7 @@ export class SeedUsersWithBooksCommand extends CommandRunner {
               lastname: faker.person.lastName(),
               password: PASSWORD_STUB_HASH,
               phoneNumber: faker.string.numeric({ length: 10 }),
+              // TODO: consider making this random, with a strong bias towards true
               emailVerified: true,
             },
           })),
@@ -204,6 +205,7 @@ export class SeedUsersWithBooksCommand extends CommandRunner {
               lastname: faker.person.lastName(),
               password: PASSWORD_STUB_HASH,
               phoneNumber: faker.string.numeric({ length: 10 }),
+              // TODO: consider making this random, with a strong bias towards true
               emailVerified: true,
             },
           })),

--- a/packages/server/src/modules/user/seed-users-with-books.command.ts
+++ b/packages/server/src/modules/user/seed-users-with-books.command.ts
@@ -458,7 +458,6 @@ export class SeedUsersWithBooksCommand extends CommandRunner {
       this.prisma,
       [bookCopy.bookId],
       retailLocationId,
-      true,
     );
 
     return this.prisma.bookCopy.update({

--- a/packages/server/src/modules/user/seed-users-with-books.command.ts
+++ b/packages/server/src/modules/user/seed-users-with-books.command.ts
@@ -123,13 +123,21 @@ export class SeedUsersWithBooksCommand extends CommandRunner {
     this.logger.log(`Creating the users for ${retailLocation.name}`);
 
     // TODO: modify this to make seeding upsert possible
-    for (let i = 0; i < this.USERS_AMOUNT; i++) {
-      try {
-        await this.#createBuyerAndSeller(i, randomDisplacement, retailLocation);
-      } catch (error) {
-        this.logger.error(error);
-        return;
-      }
+    try {
+      await Promise.all(
+        new Array(this.USERS_AMOUNT)
+          .fill(null)
+          .map((_, index) =>
+            this.#createBuyerAndSeller(
+              index,
+              randomDisplacement,
+              retailLocation,
+            ),
+          ),
+      );
+    } catch (error) {
+      this.logger.error(error);
+      return;
     }
 
     this.logger.log(`Users for ${retailLocation.name} created successfully`);

--- a/packages/server/src/modules/user/seed-users-with-books.command.ts
+++ b/packages/server/src/modules/user/seed-users-with-books.command.ts
@@ -402,7 +402,6 @@ export class SeedUsersWithBooksCommand extends CommandRunner {
           if (i % 3 === 2) {
             await this.#refundBookCopy(sale, retailLocationId);
           }
-          i++;
         }),
       );
     } catch (error) {

--- a/packages/server/src/modules/user/seed-users-with-books.command.ts
+++ b/packages/server/src/modules/user/seed-users-with-books.command.ts
@@ -96,6 +96,26 @@ export class SeedUsersWithBooksCommand extends CommandRunner {
     );
 
     for (const id of ["re", "mo"]) {
+      const { _count, name } =
+        await this.prisma.retailLocation.findFirstOrThrow({
+          where: {
+            id,
+          },
+          include: {
+            _count: {
+              select: {
+                books: true,
+              },
+            },
+          },
+        });
+
+      if (_count.books < this.BOOKS_PER_USER_BASE + (options?.random ?? 5)) {
+        this.logger.error(
+          `The random displacement is too high for the amount of books present in the warehouse of ${name}. The maximum is ${_count.books - this.BOOKS_PER_USER_BASE}`,
+        );
+        return;
+      }
       await this.#seedRetailLocation(id, options?.random);
     }
 

--- a/packages/server/src/modules/user/seed-users-with-books.command.ts
+++ b/packages/server/src/modules/user/seed-users-with-books.command.ts
@@ -373,15 +373,16 @@ export class SeedUsersWithBooksCommand extends CommandRunner {
       });
 
       // Connect requests and reservations to the sales
-      let i = 0;
-      for (const sale of sales) {
-        await this.#updateReservationsRequestsAndCart(sale, cart);
+      await Promise.all(
+        sales.map(async (sale, i) => {
+          await this.#updateReservationsRequestsAndCart(sale, cart);
 
-        if (i % 3 === 2) {
-          await this.#refundBookCopy(sale, retailLocationId);
-        }
-        i++;
-      }
+          if (i % 3 === 2) {
+            await this.#refundBookCopy(sale, retailLocationId);
+          }
+          i++;
+        }),
+      );
     } catch (error) {
       this.logger.error("Something went wrong: ", error);
     }

--- a/packages/server/src/modules/user/seed-users-with-books.command.ts
+++ b/packages/server/src/modules/user/seed-users-with-books.command.ts
@@ -1,0 +1,518 @@
+import { randomInt } from "crypto";
+import { faker } from "@faker-js/faker";
+import { Logger } from "@nestjs/common";
+import {
+  Book,
+  BookCopy,
+  BookRequest,
+  Cart,
+  Prisma,
+  Reservation,
+  RetailLocation,
+  Sale,
+} from "@prisma/client";
+import { Command, CommandRunner, Option } from "nest-commander";
+import { PASSWORD_STUB_HASH } from "prisma/factories/user";
+import { BookCopyService } from "src/modules/book-copy/book-copy.service";
+import { PrismaService } from "src/modules/prisma/prisma.service";
+
+interface SeedUsersWithBooksCommandOptions {
+  random?: number;
+  clear?: boolean;
+}
+
+@Command({
+  name: "seed-users-with-books",
+  description:
+    "Seeds the current database with some users and books movements/reservations/requests",
+})
+export class SeedUsersWithBooksCommand extends CommandRunner {
+  private readonly logger = new Logger(SeedUsersWithBooksCommand.name);
+  private readonly bookService = new BookCopyService();
+
+  private readonly USERS_AMOUNT = 5;
+  private readonly BOOKS_PER_USER_BASE = 10;
+  // Displacement for the actual generated random number of books per user, above the base
+  private readonly DEFAULT_RANDOM_DISPLACEMENT = 5;
+  // Some character combination that is not valid in an email, to avoid matching with real data
+  private readonly EMAIL_SEEDING_SUFFIX = "@@";
+
+  constructor(private readonly prisma: PrismaService) {
+    super();
+  }
+
+  @Option({
+    flags: "-r, --random [number]",
+    description:
+      "The amount of displacement of the random number of copies between every generated user\nAccepted values: natural numbers (default: 5)",
+  })
+  parseRandomDisplacement(val?: string) {
+    if (
+      val !== undefined &&
+      (parseInt(val) <= 0 ||
+        parseInt(val) !== parseFloat(val) ||
+        isNaN(parseInt(val)))
+    ) {
+      throw new Error(
+        "Invalid displacement, must be an integer greater than zero",
+      );
+    }
+    return val !== undefined ? parseInt(val) : val;
+  }
+
+  @Option({
+    flags: "-c, --clear",
+    description:
+      "Makes the command stop after clearing the previous seeded data",
+  })
+  parseNothing(_?: string) {
+    return true;
+  }
+
+  async run(
+    _: string[],
+    options?: SeedUsersWithBooksCommandOptions,
+  ): Promise<void> {
+    // TODO: make the clear of the seeded users optional once seeding upsert is allowed
+    try {
+      await this.#clearRetailLocationSeededUsers();
+    } catch (error) {
+      this.logger.error(
+        "There was a problem while cleaning any previously seeded users",
+        error,
+      );
+      return;
+    }
+
+    this.logger.log("Seed data erased successfully");
+
+    if (options?.clear) {
+      // Option to only clear the current seeded data
+      return;
+    }
+
+    this.logger.verbose(
+      `Range of copies created per user: ${this.BOOKS_PER_USER_BASE} - ${this.BOOKS_PER_USER_BASE + (options?.random ?? this.DEFAULT_RANDOM_DISPLACEMENT)}`,
+    );
+
+    for (const id of ["re", "mo"]) {
+      await this.#seedRetailLocation(id, options?.random);
+    }
+
+    this.logger.log("Seeding complete");
+  }
+
+  async #seedRetailLocation(
+    retailLocationId: string,
+    randomDisplacement = this.DEFAULT_RANDOM_DISPLACEMENT,
+  ) {
+    let retailLocation: RetailLocation | undefined;
+    try {
+      retailLocation = await this.prisma.retailLocation.findUniqueOrThrow({
+        where: {
+          id: retailLocationId,
+        },
+      });
+    } catch {
+      this.logger.error(
+        "Something went wrong while fetching the current location",
+      );
+      return;
+    }
+
+    this.logger.log(`Creating the users for ${retailLocation.name}`);
+
+    // TODO: modify this to make seeding upsert possible
+    for (let i = 0; i < this.USERS_AMOUNT; i++) {
+      try {
+        await this.#createBuyerAndSeller(i, randomDisplacement, retailLocation);
+      } catch (error) {
+        this.logger.error(error);
+        return;
+      }
+    }
+
+    this.logger.log(`Users for ${retailLocation.name} created successfully`);
+  }
+
+  async #createBuyerAndSeller(
+    index: number,
+    randomDisplacement: number,
+    retailLocation: RetailLocation,
+  ) {
+    try {
+      const bookIds = (
+        await this.prisma.book.findMany({
+          take: randomInt(
+            this.BOOKS_PER_USER_BASE,
+            this.BOOKS_PER_USER_BASE + randomDisplacement,
+          ),
+          where: {
+            retailLocationId: retailLocation.id,
+            copies: {
+              none: {},
+            },
+          },
+          orderBy: {
+            isbnCode: "asc",
+          },
+        })
+      ).map(({ id }) => id);
+
+      if (bookIds.length === 0) {
+        throw new Error(
+          "Import books into the database before calling this command.",
+        );
+      }
+
+      const [seller, buyer] = await Promise.all([
+        (await this.prisma.user.findUnique({
+          where: {
+            email: `${index + 1}-user-seller${this.EMAIL_SEEDING_SUFFIX}`,
+          },
+        })) ??
+          (await this.prisma.user.create({
+            data: {
+              dateOfBirth: faker.date.past(),
+              email: `${index + 1}-user-seller${this.EMAIL_SEEDING_SUFFIX}`,
+              firstname: faker.person.firstName(),
+              lastname: faker.person.lastName(),
+              password: PASSWORD_STUB_HASH,
+              phoneNumber: faker.string.numeric({ length: 10 }),
+              emailVerified: true,
+            },
+          })),
+
+        (await this.prisma.user.findUnique({
+          where: {
+            email: `${index + 1}-user-buyer${this.EMAIL_SEEDING_SUFFIX}`,
+          },
+        })) ??
+          (await this.prisma.user.create({
+            data: {
+              dateOfBirth: faker.date.past(),
+              email: `${index + 1}-user-buyer${this.EMAIL_SEEDING_SUFFIX}`,
+              firstname: faker.person.firstName(),
+              lastname: faker.person.lastName(),
+              password: PASSWORD_STUB_HASH,
+              phoneNumber: faker.string.numeric({ length: 10 }),
+              emailVerified: true,
+            },
+          })),
+      ]);
+
+      const retailLocationId = retailLocation.id;
+
+      const booksCodes = await this.bookService.calculateBookCodes(
+        this.prisma,
+        bookIds,
+        retailLocationId,
+      );
+
+      await this.prisma.bookCopy.createMany({
+        data: booksCodes.map((code, bookIndex) => ({
+          ownerId: seller.id,
+          createdById: seller.id,
+          bookId: bookIds[bookIndex],
+          updatedById: seller.id,
+          code,
+        })),
+      });
+
+      const availableCopies = await this.prisma.bookCopy.findMany({
+        where: {
+          ownerId: seller.id,
+          book: {
+            id: {
+              in: bookIds,
+            },
+            retailLocationId,
+          },
+        },
+      });
+
+      await this.prisma.bookRequest.createMany({
+        data: availableCopies.slice(0, availableCopies.length - 2).map(
+          ({ bookId }) =>
+            ({
+              bookId,
+              createdById: buyer.id,
+              userId: buyer.id,
+            }) satisfies Prisma.BookRequestCreateManyInput,
+        ),
+      });
+
+      const availableRequests = await this.prisma.bookRequest.findMany({
+        where: {
+          bookId: {
+            in: bookIds,
+          },
+          userId: buyer.id,
+          saleId: null,
+        },
+      });
+
+      await this.prisma.reservation.createMany({
+        data: availableRequests
+          .slice(0, availableRequests.length - 2)
+          .map(({ bookId, id }) => ({
+            requestId: id,
+            bookId,
+            createdById: buyer.id,
+            expiresAt: new Date(
+              Date.now() + retailLocation.maxBookingDays * 24 * 60 * 60 * 1000,
+            ),
+            userId: buyer.id,
+          })),
+      });
+
+      const reservations = await this.prisma.reservation.findMany({
+        where: {
+          userId: buyer.id,
+          request: {
+            userId: buyer.id,
+            saleId: null,
+          },
+          bookId: {
+            in: bookIds,
+          },
+        },
+      });
+
+      const cart = await this.prisma.cart.create({
+        data: {
+          items: {
+            create: reservations
+              .slice(0, reservations.length - 2)
+              .map(({ id, bookId }) => ({
+                fromReservationId: id,
+                bookId,
+              })),
+          },
+          userId: buyer.id,
+          createdById: buyer.id,
+          retailLocationId,
+        },
+        include: {
+          items: {
+            include: {
+              book: {
+                include: {
+                  copies: {
+                    where: {
+                      OR: [
+                        {
+                          sales: {
+                            none: {},
+                          },
+                        },
+                        {
+                          sales: {
+                            every: {
+                              refundedAt: {
+                                not: null,
+                              },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const itemsToSell = cart.items.slice(0, cart.items.length - 2);
+
+      await this.prisma.sale.createMany({
+        data: itemsToSell.map((item) => ({
+          bookCopyId: item.book.copies[0].id,
+          cartCreatedById: buyer.id,
+          createdById: buyer.id,
+          purchasedAt: new Date(),
+          purchasedById: buyer.id,
+        })),
+      });
+
+      const sales = await this.prisma.sale.findMany({
+        where: {
+          bookCopy: {
+            book: {
+              retailLocationId,
+            },
+          },
+          purchasedById: buyer.id,
+          bookCopyId: {
+            in: itemsToSell.map(({ book }) => book.copies[0].id),
+          },
+        },
+        include: {
+          bookCopy: {
+            include: {
+              book: {
+                include: {
+                  requests: true,
+                  reservations: true,
+                },
+              },
+              sales: true,
+            },
+          },
+        },
+      });
+
+      // Connect requests and reservations to the sales
+      let i = 0;
+      for (const sale of sales) {
+        await this.#updateReservationsRequestsAndCart(sale, cart);
+
+        if (i % 3 === 2) {
+          await this.#refundBookCopy(sale, retailLocationId);
+        }
+        i++;
+      }
+    } catch (error) {
+      this.logger.error("Something went wrong: ", error);
+    }
+  }
+
+  async #updateReservationsRequestsAndCart(
+    sale: {
+      bookCopy: {
+        book: {
+          reservations: Reservation[];
+          requests: BookRequest[];
+        } & Book;
+      };
+    } & Sale,
+    cart: Cart,
+  ) {
+    const book = sale.bookCopy.book;
+    await this.prisma.cartItem.delete({
+      where: {
+        cartId_bookId: {
+          bookId: book.id,
+          cartId: cart.id,
+        },
+      },
+    });
+
+    if (book.requests.length > 0) {
+      const request = book.requests.find(
+        ({ userId, saleId }) =>
+          userId === sale.purchasedById && saleId === null,
+      );
+      if (!request) {
+        throw new Error(
+          `Could not update the request associated with this book: ${book.id}`,
+        );
+      }
+
+      await this.prisma.bookRequest.update({
+        where: { id: request.id },
+        data: {
+          saleId: sale.id,
+        },
+      });
+    }
+
+    if (book.reservations.length > 0) {
+      const reservation = book.reservations.find(
+        ({ userId, saleId }) =>
+          userId === sale.purchasedById && saleId === null,
+      );
+      if (!reservation) {
+        throw new Error(
+          `Could not update the request associated with this book: ${book.id}`,
+        );
+      }
+
+      await this.prisma.reservation.update({
+        where: { id: reservation.id },
+        data: {
+          saleId: sale.id,
+        },
+      });
+    }
+  }
+
+  async #refundBookCopy(
+    { id, bookCopyId, bookCopy }: Sale & { bookCopy: BookCopy },
+    retailLocationId: string,
+  ) {
+    const [newBookCopyCode] = await this.bookService.calculateBookCodes(
+      this.prisma,
+      [bookCopy.bookId],
+      retailLocationId,
+      true,
+    );
+
+    return this.prisma.bookCopy.update({
+      where: {
+        id: bookCopyId,
+      },
+      data: {
+        code: newBookCopyCode,
+        // Original code must be updated only the first time a book is returned, so when there is no original code set.
+        ...(bookCopy.originalCode ? {} : { originalCode: bookCopy.code }),
+        updatedAt: new Date(),
+        sales: {
+          update: {
+            where: {
+              id,
+            },
+            data: {
+              refundedAt: new Date(),
+            },
+          },
+        },
+      },
+    });
+  }
+
+  async #clearRetailLocationSeededUsers() {
+    // For filtering for the seeded users
+    const seedUserFilter = {
+      email: {
+        contains: this.EMAIL_SEEDING_SUFFIX,
+      },
+    };
+
+    await this.prisma.sale.deleteMany({
+      where: {
+        purchasedBy: seedUserFilter,
+      },
+    });
+
+    await this.prisma.cart.deleteMany({
+      where: {
+        user: seedUserFilter,
+      },
+    });
+
+    await this.prisma.reservation.deleteMany({
+      where: {
+        user: seedUserFilter,
+      },
+    });
+
+    await this.prisma.bookRequest.deleteMany({
+      where: {
+        user: seedUserFilter,
+      },
+    });
+
+    await this.prisma.bookCopy.deleteMany({
+      where: {
+        owner: seedUserFilter,
+      },
+    });
+
+    await this.prisma.user.deleteMany({
+      where: seedUserFilter,
+    });
+  }
+}

--- a/packages/server/src/modules/user/user.module.ts
+++ b/packages/server/src/modules/user/user.module.ts
@@ -1,13 +1,20 @@
 import { Module, forwardRef } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
 import { AuthModule } from "src/modules/auth/auth.module";
+import { AddAdminUserCommand } from "src/modules/user/add-admin-user.command";
 import { UserAccountResolver } from "src/modules/user/user-account.resolver";
 import { PrismaModule } from "../prisma/prisma.module";
 import { UserResolver } from "./user.resolver";
 import { UserService } from "./user.service";
 
 @Module({
-  imports: [PrismaModule, forwardRef(() => AuthModule)],
-  providers: [UserResolver, UserAccountResolver, UserService],
+  imports: [PrismaModule, forwardRef(() => AuthModule), ConfigModule],
+  providers: [
+    UserResolver,
+    UserAccountResolver,
+    UserService,
+    AddAdminUserCommand,
+  ],
   exports: [UserService],
 })
 export class UserModule {}

--- a/packages/server/src/modules/user/user.module.ts
+++ b/packages/server/src/modules/user/user.module.ts
@@ -2,6 +2,7 @@ import { Module, forwardRef } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 import { AuthModule } from "src/modules/auth/auth.module";
 import { AddAdminUserCommand } from "src/modules/user/add-admin-user.command";
+import { SeedUsersWithBooksCommand } from "src/modules/user/seed-users-with-books.command";
 import { UserAccountResolver } from "src/modules/user/user-account.resolver";
 import { PrismaModule } from "../prisma/prisma.module";
 import { UserResolver } from "./user.resolver";
@@ -14,6 +15,7 @@ import { UserService } from "./user.service";
     UserAccountResolver,
     UserService,
     AddAdminUserCommand,
+    SeedUsersWithBooksCommand,
   ],
   exports: [UserService],
 })

--- a/packages/server/src/modules/user/user.resolver.ts
+++ b/packages/server/src/modules/user/user.resolver.ts
@@ -204,6 +204,9 @@ export class UserResolver {
         skip: page * rowsPerPage,
         take: rowsPerPage,
         where,
+        orderBy: {
+          email: "asc",
+        },
       }),
     ]);
 
@@ -456,6 +459,18 @@ export class UserResolver {
                 book: {
                   retailLocationId,
                 },
+                OR: [
+                  {
+                    sale: {
+                      refundedAt: {
+                        not: null,
+                      },
+                    },
+                  },
+                  {
+                    saleId: null,
+                  },
+                ],
               },
             },
           },

--- a/packages/server/test/fixtures/retail-locations.ts
+++ b/packages/server/test/fixtures/retail-locations.ts
@@ -401,19 +401,19 @@ const IT_MO_FAQ = `<section class="article-intro clearfix">
 </section>
 `;
 
-interface retailLocationInfo {
+interface RetailLocationInfo {
   whoAreWeContent: string;
   joinUsContent: string;
   faqContent: string;
 }
 
-type locales = "it" | "en-US";
+type Locales = "it" | "en-US";
 
-type translatedRetailLocationCreateInput = Prisma.RetailLocationCreateInput & {
-  infoPagesContent: Record<locales, retailLocationInfo>;
+type TranslatedRetailLocationCreateInput = Prisma.RetailLocationCreateInput & {
+  infoPagesContent: Record<Locales, RetailLocationInfo>;
 };
 
-export const RE_RETAIL_POINT: translatedRetailLocationCreateInput = {
+export const RE_RETAIL_POINT: TranslatedRetailLocationCreateInput = {
   id: "re",
   name: "Reggio Emilia",
   email: "info@ilmercatinodellibro.com",
@@ -445,7 +445,7 @@ export const RE_RETAIL_POINT: translatedRetailLocationCreateInput = {
   } satisfies Theme,
 };
 
-export const MO_RETAIL_POINT: translatedRetailLocationCreateInput = {
+export const MO_RETAIL_POINT: TranslatedRetailLocationCreateInput = {
   id: "mo",
   name: "Modena",
   email: " info-mo@ilmercatinodellibro.com",


### PR DESCRIPTION
 ## What it does
This feature implements two pnpm script commands:
- `add-admin` for adding/repairing the default admin user
- `seed-users-with-books` for seeding the database with some sample users, and sample data

## How to test it
Open a terminal from the root folder of the project, and run `pnpm i`, then navigate to the `/packages/server` folder (via `cd .\packages\server`) and run `pnpm build`

Afterwards, still on a terminal in the server folder, run
- `pnpm add-admin` to add or repair the default admin user
- `pnpm seed-users-with-books` to seed the database with some sample users and sample data
- `pnpm seed-users-with-books:clear` to erase the seeded data