### PR TITLE
feat(client+server): allow admin to resend verification

### DIFF
--- a/packages/client/src/components/manage-users/edit-user-details-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-details-dialog.vue
@@ -298,16 +298,14 @@ const newUserData = ref(
 const hidePassword = ref(true);
 const hideConfirm = ref(true);
 
-const { sendVerificationLink } = useSendVerificationLinkMutation();
-const sendingEmail = ref(false);
+const { loading: sendingEmail, sendVerificationLink } =
+  useSendVerificationLinkMutation();
 async function sendVerificationEmail() {
   if (!userData) {
     return;
   }
 
   try {
-    sendingEmail.value = true;
-
     await sendVerificationLink({
       input: {
         retailLocationId: selectedLocation.value.id,
@@ -315,14 +313,11 @@ async function sendVerificationEmail() {
       },
     });
 
-    sendingEmail.value = false;
-
     Notify.create({
       type: "positive",
       message: t("auth.verificationEmailSent"),
     });
   } catch {
-    sendingEmail.value = false;
     notifyError(t("auth.couldNotSendVerificationEmail"));
   }
 }

--- a/packages/client/src/components/manage-users/edit-user-details-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-details-dialog.vue
@@ -80,7 +80,26 @@
           clearable
           outlined
           @clear="newUserData.email = ''"
-        />
+        >
+          <template
+            v-if="hasAdminRole && userData && !userData.emailVerified"
+            #after
+          >
+            <q-btn
+              :icon="mdiEmailArrowRight"
+              :loading="sendingEmail"
+              color="primary"
+              flat
+              round
+              @click="sendVerificationEmail"
+            >
+              <q-tooltip>
+                {{ t("auth.resendVerificationEmail") }}
+              </q-tooltip>
+            </q-btn>
+          </template>
+        </q-input>
+
         <q-input
           v-model="newUserData.phoneNumber"
           :disable="scheduledForDeletion"
@@ -211,15 +230,17 @@ import {
   mdiAccountReactivate,
   mdiAccountRemove,
   mdiDownload,
+  mdiEmailArrowRight,
   mdiEye,
   mdiEyeOff,
   mdiInformationOutline,
 } from "@quasar/extras/mdi-v7";
 import { formatDate } from "@vueuse/core";
-import { useDialogPluginComponent } from "quasar";
+import { Notify, useDialogPluginComponent } from "quasar";
 import { ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { RegisterUserPayload, UpdateUserPayload } from "src/@generated/graphql";
+import { notifyError } from "src/helpers/error-messages";
 import {
   emailRule,
   makeValueMatchRule,
@@ -230,12 +251,14 @@ import {
 } from "src/helpers/rules";
 import { UserDialogPayload } from "src/models/user";
 import { useAuthService } from "src/services/auth";
+import { useSendVerificationLinkMutation } from "src/services/auth.graphql";
 import { useRetailLocationService } from "src/services/retail-location";
+import { CustomerFragment } from "src/services/user.graphql";
 import KDialogFormCard from "../k-dialog-form-card.vue";
 
 // We don't need reactivity on the props as this is used through the Dialog plugin
 const { userData, scheduledForDeletion } = defineProps<{
-  userData?: UpdateUserPayload;
+  userData?: UpdateUserPayload & Pick<CustomerFragment, "emailVerified">;
   scheduledForDeletion?: boolean;
 }>();
 
@@ -274,4 +297,33 @@ const newUserData = ref(
 );
 const hidePassword = ref(true);
 const hideConfirm = ref(true);
+
+const { sendVerificationLink } = useSendVerificationLinkMutation();
+const sendingEmail = ref(false);
+async function sendVerificationEmail() {
+  if (!userData) {
+    return;
+  }
+
+  try {
+    sendingEmail.value = true;
+
+    await sendVerificationLink({
+      input: {
+        retailLocationId: selectedLocation.value.id,
+        userId: userData.id,
+      },
+    });
+
+    sendingEmail.value = false;
+
+    Notify.create({
+      type: "positive",
+      message: t("auth.verificationEmailSent"),
+    });
+  } catch {
+    sendingEmail.value = false;
+    notifyError(t("auth.couldNotSendVerificationEmail"));
+  }
+}
 </script>

--- a/packages/client/src/i18n/en-US/auth.ts
+++ b/packages/client/src/i18n/en-US/auth.ts
@@ -31,6 +31,8 @@ export default {
   logOut: "Log out",
   passwordChangedSuccessfully: "Your password has been changed successfully",
   passwordDoNotMatch: "Passwords do not match",
+  resendVerificationEmail: "Send a new verification email",
+  couldNotSendVerificationEmail: "Could not send the verification email",
   emailVerified:
     "Your email has been correctly verified, you can now login using your credentials",
   emailNotVerified: "This user's account was not verified yet",

--- a/packages/client/src/i18n/en-US/manage-users.ts
+++ b/packages/client/src/i18n/en-US/manage-users.ts
@@ -1,4 +1,4 @@
-import { ReceiptType } from "src/@generated/graphql";
+import { ReceiptType, UserQueryFilters } from "src/@generated/graphql";
 
 export default {
   createUser: "Create new user",
@@ -38,7 +38,8 @@ export default {
     withRequested: "With Requested",
     withPurchased: "With Purchased",
     withSold: "With Sold",
-  },
+    unverified: "Unverified",
+  } satisfies Record<Exclude<keyof UserQueryFilters, "search">, string>,
   editUser: {
     title: "Edit User Data",
     createUser: "Create a New User",

--- a/packages/client/src/i18n/it/auth.ts
+++ b/packages/client/src/i18n/it/auth.ts
@@ -32,6 +32,9 @@ export default {
   passwordChangedSuccessfully:
     "La tua password è stata modificata correttamente",
   passwordDoNotMatch: "Le password non corrispondono",
+  resendVerificationEmail: "Manda una nuova e-mail di verifica",
+  couldNotSendVerificationEmail:
+    "Non è stato possibile mandare l'e-mail di verifica",
   emailVerified:
     "La tua email è stata verificata correttamente, ora puoi accedere utilizzando le tue credenziali",
   emailNotVerified: "L’account di questo utente non è ancora stato verificato",

--- a/packages/client/src/i18n/it/manage-users.ts
+++ b/packages/client/src/i18n/it/manage-users.ts
@@ -1,4 +1,4 @@
-import { ReceiptType } from "src/@generated/graphql";
+import { ReceiptType, UserQueryFilters } from "src/@generated/graphql";
 
 export default {
   createUser: "Crea nuovo utente",
@@ -38,7 +38,8 @@ export default {
     withRequested: "Con Richiesti",
     withPurchased: "Con Acquistati",
     withSold: "Con Venduti",
-  },
+    unverified: "Non verificati",
+  } satisfies Record<Exclude<keyof UserQueryFilters, "search">, string>,
   editUser: {
     title: "Modifica Dati Utente",
     createUser: "Crea un Nuovo Utente",

--- a/packages/client/src/pages/manage-users.vue
+++ b/packages/client/src/pages/manage-users.vue
@@ -233,7 +233,6 @@ import {
 import { Dialog, Notify, QTable, QTableColumn, QTableProps } from "quasar";
 import { Ref, computed, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
-import { UpdateUserPayload } from "src/@generated/graphql";
 import HeaderSearchBarFilters from "src/components/header-search-bar-filters.vue";
 import CartDialog from "src/components/manage-users/cart-dialog.vue";
 import ChipButton from "src/components/manage-users/chip-button.vue";
@@ -466,6 +465,7 @@ function openEdit({
   dateOfBirth,
   delegate,
   scheduledForDeletionAt,
+  emailVerified,
 }: CustomerFragment) {
   Dialog.create({
     component: EditUserDetailsDialog,
@@ -481,9 +481,10 @@ function openEdit({
         retailLocationId: selectedLocation.value.id,
         dateOfBirth,
         delegate,
-      } satisfies UpdateUserPayload,
+        emailVerified,
+      },
       scheduledForDeletion: !!scheduledForDeletionAt,
-    },
+    } satisfies InstanceType<typeof EditUserDetailsDialog>["$props"],
   }).onOk(async (payload: Exclude<UserDialogPayload, { type: "create" }>) => {
     if (payload.type === "toggleDeletion") {
       const shouldDelete = !scheduledForDeletionAt;

--- a/packages/client/src/services/auth.graphql
+++ b/packages/client/src/services/auth.graphql
@@ -42,6 +42,10 @@ mutation refreshToken {
   refreshToken
 }
 
+mutation sendVerificationLink($input: EmailVerificationPayload!) {
+  sendVerificationLink(input: $input)
+}
+
 mutation resetPassword($input: PasswordResetPayload!) {
   resetPassword(input: $input)
 }

--- a/packages/server/src/modules/auth/auth.args.ts
+++ b/packages/server/src/modules/auth/auth.args.ts
@@ -51,6 +51,12 @@ export class RegistrationInviteLinkPayload extends LocationBoundInput {
 }
 
 @InputType()
+export class EmailVerificationPayload extends LocationBoundInput {
+  @Field()
+  userId!: string;
+}
+
+@InputType()
 export class ResetForgottenPasswordPayload {
   @Field()
   newPassword!: string;

--- a/packages/server/src/modules/auth/auth.resolver.ts
+++ b/packages/server/src/modules/auth/auth.resolver.ts
@@ -206,16 +206,13 @@ export class AuthResolver {
   ) {
     await this.authService.assertMembership({
       userId: currentUser.id,
-      role: "ADMIN",
+      role: Role.ADMIN,
       message: "Operation not allowed",
     });
 
     const userToVerify = await this.prisma.user.findUniqueOrThrow({
       where: {
         id: userId,
-      },
-      include: {
-        memberships: true,
       },
     });
 

--- a/packages/server/src/modules/auth/auth.resolver.ts
+++ b/packages/server/src/modules/auth/auth.resolver.ts
@@ -8,6 +8,7 @@ import { PrismaService } from "src/modules/prisma/prisma.service";
 import { RegisterUserPayload } from "src/modules/user/user.args";
 import { UserService } from "../user/user.service";
 import {
+  EmailVerificationPayload,
   LoginPayload,
   PasswordResetLinkPayload,
   PasswordResetPayload,
@@ -196,6 +197,38 @@ export class AuthResolver {
   @Mutation(() => String)
   refreshToken(@CurrentUser() user: User) {
     return this.authService.createAccessToken(user.id);
+  }
+
+  @Mutation(() => GraphQLVoid, { nullable: true })
+  async sendVerificationLink(
+    @Input() { userId, retailLocationId }: EmailVerificationPayload,
+    @CurrentUser() currentUser: User,
+  ) {
+    await this.authService.assertMembership({
+      userId: currentUser.id,
+      role: "ADMIN",
+      message: "Operation not allowed",
+    });
+
+    const userToVerify = await this.prisma.user.findUniqueOrThrow({
+      where: {
+        id: userId,
+      },
+      include: {
+        memberships: true,
+      },
+    });
+
+    const token = this.authService.createVerificationToken(
+      retailLocationId,
+      userToVerify.email,
+    );
+
+    await this.authService.sendVerificationLink(
+      retailLocationId,
+      userToVerify,
+      token,
+    );
   }
 
   @Mutation(() => GraphQLVoid, { nullable: true })

--- a/packages/server/src/modules/user/user.args.ts
+++ b/packages/server/src/modules/user/user.args.ts
@@ -32,6 +32,9 @@ export class UserQueryFilters {
 
   @Field(() => Boolean, { nullable: true })
   withSold?: boolean;
+
+  @Field(() => Boolean, { nullable: true })
+  unverified?: boolean;
 }
 
 @ArgsType()

--- a/packages/server/src/modules/user/user.resolver.ts
+++ b/packages/server/src/modules/user/user.resolver.ts
@@ -107,6 +107,10 @@ export class UserResolver {
           ],
         },
 
+        ...(filter.unverified
+          ? [{ emailVerified: false } satisfies Prisma.UserWhereInput]
+          : []),
+
         {
           OR: [
             ...(filter.withRequested === true || filter.withAvailable === true


### PR DESCRIPTION
fixes #139
## What it does
This feature adds a button to the admins' user data edit dialog to send a new verification email to users that are unverified
It also adds a new filter to show unverified users in the users management page

## How to test it
1: Log in as admin, go to the users management page, click the button to edit any unverified user's data and click on the button to send the verification email
2: In the users management page, click the filters select and enable "unverified"