### PR TITLE
feat(client+server): resend verification on email change

### DIFF
--- a/packages/client/src/i18n/en-US/auth.ts
+++ b/packages/client/src/i18n/en-US/auth.ts
@@ -27,7 +27,7 @@ export default {
   goToLogin: "Go to the login",
   verificationEmailSent: "Verification email sent.",
   pleaseCheckYourInboxForVerificationEmail:
-    "Check your inbox for a verification email.",
+    "Check your inbox for the verification email.",
   logOut: "Log out",
   passwordChangedSuccessfully: "Your password has been changed successfully",
   passwordDoNotMatch: "Passwords do not match",

--- a/packages/client/src/i18n/it/auth.ts
+++ b/packages/client/src/i18n/it/auth.ts
@@ -27,7 +27,7 @@ export default {
   goToLogin: "Effettua il log in",
   verificationEmailSent: "Email di verifica inviata!",
   pleaseCheckYourInboxForVerificationEmail:
-    "Controlla la tua casella di posta per un'e-mail di verifica.",
+    "Controlla la tua casella di posta per l'e-mail di verifica.",
   logOut: "Esci",
   passwordChangedSuccessfully:
     "La tua password è stata modificata correttamente",

--- a/packages/client/src/pages/manage-users.vue
+++ b/packages/client/src/pages/manage-users.vue
@@ -522,6 +522,9 @@ function openEdit({
       await updateUser({
         input: {
           ...newUserData,
+
+          // TODO: Add a way to log out the corresponding user if their email gets updated (and now unverified)
+          // This is unlikely to happen so it's left to a future implementation for now
           email:
             newUserData.email && newUserData.email !== email
               ? newUserData.email

--- a/packages/client/src/pages/manage-users.vue
+++ b/packages/client/src/pages/manage-users.vue
@@ -528,7 +528,7 @@ function openEdit({
           email:
             newUserData.email && newUserData.email !== email
               ? newUserData.email
-              : email,
+              : undefined,
           password: newUserData.password ? newUserData.password : undefined,
         },
       });

--- a/packages/client/src/pages/my-data.vue
+++ b/packages/client/src/pages/my-data.vue
@@ -73,7 +73,7 @@ import {
   mdiMail,
   mdiPhone,
 } from "@quasar/extras/mdi-v7";
-import { Dialog, date } from "quasar";
+import { Dialog, Notify, date } from "quasar";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { UpdateUserPayload } from "src/@generated/graphql";
@@ -161,6 +161,15 @@ function modifyUserData() {
         },
       });
       updateCurrentUser(updatedUser);
+
+      if (!updatedUser.emailVerified) {
+        logout();
+
+        Notify.create({
+          type: "warning",
+          message: t("auth.pleaseCheckYourInboxForVerificationEmail"),
+        });
+      }
     } catch {
       notifyError(t("auth.couldNotUpdate"));
     }

--- a/packages/client/src/pages/my-data.vue
+++ b/packages/client/src/pages/my-data.vue
@@ -154,7 +154,7 @@ function modifyUserData() {
           email:
             newUserData.email && newUserData.email !== user.value.email
               ? newUserData.email
-              : user.value.email,
+              : undefined,
           password: newUserData.password ? newUserData.password : undefined,
           id: user.value.id,
           retailLocationId: selectedLocation.value.id,

--- a/packages/client/src/services/user.graphql
+++ b/packages/client/src/services/user.graphql
@@ -102,6 +102,7 @@ mutation updateUser($input: UpdateUserPayload!) {
   updateUser(input: $input) {
     # Request just enough data so that the cache gets updated automatically
     ...UpdatableUserInfo
+    emailVerified
   }
 }
 

--- a/packages/server/src/modules/user/user.resolver.ts
+++ b/packages/server/src/modules/user/user.resolver.ts
@@ -679,6 +679,7 @@ export class UserResolver {
       discount,
       password,
       passwordConfirmation,
+      email: newEmail,
       ...payloadRest
     }: UpdateUserPayload,
     @CurrentUser() actor: User,
@@ -691,9 +692,12 @@ export class UserResolver {
       });
     }
 
-    await this.prisma.user.findFirstOrThrow({
+    const { email: oldEmail } = await this.prisma.user.findFirstOrThrow({
       where: {
         id: userId,
+      },
+      select: {
+        email: true,
       },
     });
 
@@ -721,11 +725,14 @@ export class UserResolver {
       retailLocationId,
     );
 
-    return this.prisma.user.update({
+    const updatedUser = await this.prisma.user.update({
       where: {
         id: userId,
       },
       data: {
+        ...(newEmail && newEmail !== oldEmail
+          ? { email: newEmail, emailVerified: false }
+          : {}),
         ...payloadRest,
         ...(userIsAdmin ? { discount } : {}),
         ...(!!password &&
@@ -735,6 +742,21 @@ export class UserResolver {
           : {}),
       },
     });
+
+    if (oldEmail !== newEmail) {
+      const token = this.authService.createVerificationToken(
+        retailLocationId,
+        newEmail ?? oldEmail,
+      );
+
+      await this.authService.sendVerificationLink(
+        retailLocationId,
+        updatedUser,
+        token,
+      );
+    }
+
+    return updatedUser;
   }
 
   @Mutation(() => GraphQLVoid, { nullable: true })

--- a/packages/server/src/modules/user/user.resolver.ts
+++ b/packages/server/src/modules/user/user.resolver.ts
@@ -725,14 +725,14 @@ export class UserResolver {
       retailLocationId,
     );
 
+    const shouldUpdateEmail = !!newEmail && newEmail !== oldEmail;
+
     const updatedUser = await this.prisma.user.update({
       where: {
         id: userId,
       },
       data: {
-        ...(newEmail && newEmail !== oldEmail
-          ? { email: newEmail, emailVerified: false }
-          : {}),
+        ...(shouldUpdateEmail ? { email: newEmail, emailVerified: false } : {}),
         ...payloadRest,
         ...(userIsAdmin ? { discount } : {}),
         ...(!!password &&
@@ -743,10 +743,10 @@ export class UserResolver {
       },
     });
 
-    if (oldEmail !== newEmail) {
+    if (shouldUpdateEmail) {
       const token = this.authService.createVerificationToken(
         retailLocationId,
-        newEmail ?? oldEmail,
+        newEmail,
       );
 
       await this.authService.sendVerificationLink(


### PR DESCRIPTION
fixes #164
## What it does
Adds checks that automatically unverifies and send a new verification email when a user updates their email

## How to test it
As a normal user, edit your own email in the My Data page
As an admin, go to the users management page and change any verified user's email