### PR TITLE
fix(client+server): add return cash only settlement action

### DIFF
--- a/packages/client/src/components/book-copy-status-chip.vue
+++ b/packages/client/src/components/book-copy-status-chip.vue
@@ -36,7 +36,7 @@ const props = defineProps<{
   hideIcon?: boolean;
 }>();
 
-function displayStatus(): Exclude<BookCopyStatus, "reimbursed"> {
+function displayStatus(): Exclude<BookCopyStatus, "reimbursed" | "settled"> {
   const status = getStatus(props.bookCopy);
   const problemType = getCurrentActiveProblem(props.bookCopy)?.type;
 
@@ -46,11 +46,13 @@ function displayStatus(): Exclude<BookCopyStatus, "reimbursed"> {
         ? "not-available"
         : problemType
       : "available"
-    : status;
+    : status === "settled"
+      ? "sold"
+      : status;
 }
 
 const IconData: Record<
-  Exclude<BookCopyStatus, "reimbursed">,
+  Exclude<BookCopyStatus, "reimbursed" | "settled">,
   { color: NamedColor; name: string }
 > = {
   "not-available": {

--- a/packages/client/src/components/manage-users/pay-off-user-dialog.vue
+++ b/packages/client/src/components/manage-users/pay-off-user-dialog.vue
@@ -728,6 +728,8 @@ function performCashOnlyCheckout() {
       });
 
       evictQuery(cache, GetSoldBookCopiesDocument);
+
+      onDialogOK();
     } catch {
       notifyError(t("manageUsers.payOffUserDialog.confirms.confirmError"));
     }

--- a/packages/client/src/components/manage-users/pay-off-user-dialog.vue
+++ b/packages/client/src/components/manage-users/pay-off-user-dialog.vue
@@ -405,10 +405,6 @@ const {
   retailLocationId: selectedLocation.value.id,
 }));
 
-const unsettledSoldBookCopies = computed(() =>
-  soldCopies.value.filter(({ settledAt }) => settledAt === null),
-);
-
 const getSettledOrToSettleCopiesPriceSum = (
   settledAt: number | null | undefined,
   book: BookSummaryFragment,
@@ -477,8 +473,8 @@ const tableRows = computed<
   {
     id: Titles.Sold,
   },
-  ...(unsettledSoldBookCopies.value.length > 0
-    ? sortByCopyCode(unsettledSoldBookCopies.value)
+  ...(soldCopies.value.length > 0
+    ? sortByCopyCode(soldCopies.value)
     : [{ id: "EMPTY" } satisfies EmptyRow]),
 ]);
 

--- a/packages/client/src/components/manage-users/pay-off-user-dialog.vue
+++ b/packages/client/src/components/manage-users/pay-off-user-dialog.vue
@@ -215,10 +215,20 @@
       <template #card-actions>
         <q-btn flat :label="$t('common.cancel')" @click="onDialogCancel" />
         <q-btn
+          :disable="totalCheckoutMoney === 0"
+          :label="
+            t('manageUsers.payOffUserDialog.cashOnly', [
+              totalCheckoutMoney.toFixed(2),
+            ])
+          "
+          outline
+          @click="performCashOnlyCheckout()"
+        />
+        <q-btn
           :disable="selectableRows.length === 0 && totalCheckoutMoney === 0"
           outline
           :label="$t('manageUsers.payOffUserDialog.returnAndDonate')"
-          @click="returnAllBooks('REFUND')"
+          @click="returnAllBooks('DONATE')"
         />
         <q-btn
           color="green"
@@ -247,12 +257,14 @@ import {
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { SettleRemainingType } from "src/@generated/graphql";
+import { evictQuery } from "src/apollo/cache";
 import KDialogCard from "src/components/k-dialog-card.vue";
 import { formatPrice } from "src/composables/use-misc-formats";
 import { discountedPrice, getStatus } from "src/helpers/book-copy";
 import { notifyError } from "src/helpers/error-messages";
 import {
   BookCopyDetailsFragment,
+  GetSoldBookCopiesDocument,
   ProblemDetailsFragment,
   useDonateBookCopyMutation,
   useGetBookCopiesInStockQuery,
@@ -393,6 +405,10 @@ const {
   retailLocationId: selectedLocation.value.id,
 }));
 
+const unsettledSoldBookCopies = computed(() =>
+  soldCopies.value.filter(({ settledAt }) => settledAt === null),
+);
+
 const getSettledOrToSettleCopiesPriceSum = (
   settledAt: number | null | undefined,
   book: BookSummaryFragment,
@@ -461,8 +477,8 @@ const tableRows = computed<
   {
     id: Titles.Sold,
   },
-  ...(soldCopies.value.length > 0
-    ? sortByCopyCode(soldCopies.value)
+  ...(unsettledSoldBookCopies.value.length > 0
+    ? sortByCopyCode(unsettledSoldBookCopies.value)
     : [{ id: "EMPTY" } satisfies EmptyRow]),
 ]);
 
@@ -652,31 +668,21 @@ function reportProblems(bookCopies: BookCopyDetailsFragment[]) {
 }
 
 const { settleUser } = useSettleUserMutation();
-function returnAllBooks(remainingType: SettleRemainingType) {
-  const translationsPath = `manageUsers.payOffUserDialog.confirms.${
-    remainingType === "REFUND" ? "returnAndDonate" : "returnEverything"
-  }`;
+function returnAllBooks(
+  remainingType: Exclude<SettleRemainingType, "CASH_ONLY">,
+) {
+  const translationsPath = `manageUsers.payOffUserDialog.confirms.bulk.${remainingType}`;
+
   Dialog.create({
     component: ReturnBooksConfirmDialog,
     componentProps: {
       booksToReturn: selectableRows.value,
       disclaimer: t(`${translationsPath}.disclaimer`),
-      saveLabel: t(
-        `manageUsers.payOffUserDialog.${
-          remainingType === "REFUND"
-            ? "confirms.returnAndDonate.buttonText"
-            : "returnEverything"
-        }`,
-        [totalCheckoutMoney.value.toFixed(2)],
-      ),
+      saveLabel: t(`${translationsPath}.saveLabel`, [
+        totalCheckoutMoney.value.toFixed(2),
+      ]),
       tableTitle: t(`${translationsPath}.tableTitle`),
-      title: t(
-        `manageUsers.payOffUserDialog.${
-          remainingType === "RETURN"
-            ? "returnAndDonate"
-            : "confirms.returnEverything.title"
-        }`,
-      ),
+      title: t(`${translationsPath}.title`),
       booksSoldToOthers: soldCopies.value.length,
       totalCheckoutMoney: totalCheckoutMoney.value,
       totalCheckedOutMoney: totalCheckedOutMoney.value,
@@ -703,6 +709,31 @@ function returnAllBooks(remainingType: SettleRemainingType) {
       onDialogOK();
     } catch {
       notifyError(t("common.genericErrorMessage"));
+    }
+  });
+}
+
+function performCashOnlyCheckout() {
+  Dialog.create({
+    title: t("manageUsers.payOffUserDialog.confirms.cashOnly.title"),
+    message: t("manageUsers.payOffUserDialog.confirms.cashOnly.message"),
+    ok: t("manageUsers.payOffUserDialog.confirms.cashOnly.saveLabel", [
+      totalCheckoutMoney.value.toFixed(2),
+    ]),
+    cancel: t("common.cancel"),
+  }).onOk(async () => {
+    try {
+      const { cache } = await settleUser({
+        input: {
+          remainingType: "CASH_ONLY",
+          retailLocationId: selectedLocation.value.id,
+          userId: props.user.id,
+        },
+      });
+
+      evictQuery(cache, GetSoldBookCopiesDocument);
+    } catch {
+      notifyError(t("manageUsers.payOffUserDialog.confirms.confirmError"));
     }
   });
 }

--- a/packages/client/src/components/manage-users/pay-off-user-dialog.vue
+++ b/packages/client/src/components/manage-users/pay-off-user-dialog.vue
@@ -227,7 +227,11 @@
         <q-btn
           :disable="selectableRows.length === 0 && totalCheckoutMoney === 0"
           outline
-          :label="$t('manageUsers.payOffUserDialog.returnAndDonate')"
+          :label="
+            $t('manageUsers.payOffUserDialog.returnAndDonate', [
+              totalCheckoutMoney.toFixed(2),
+            ])
+          "
           @click="returnAllBooks('DONATE')"
         />
         <q-btn

--- a/packages/client/src/helpers/book-copy.ts
+++ b/packages/client/src/helpers/book-copy.ts
@@ -24,6 +24,7 @@ export type BookCopyStatus =
   | "returned"
   | "sold"
   | "reimbursed"
+  | "settled"
   | Exclude<ProblemType, "CUSTOM">;
 
 export function getStatus(bookCopy: BookCopyDetailsFragment): BookCopyStatus {
@@ -36,7 +37,9 @@ export function getStatus(bookCopy: BookCopyDetailsFragment): BookCopyStatus {
       : bookCopy.purchasedAt &&
           (!bookCopy.returnedAt ||
             bookCopy.sales?.some(({ refundedAt }) => !refundedAt))
-        ? "sold"
+        ? bookCopy.settledAt
+          ? "settled"
+          : "sold"
         : bookCopy.donatedAt
           ? "donated"
           : problemType

--- a/packages/client/src/i18n/en-US/manage-users.ts
+++ b/packages/client/src/i18n/en-US/manage-users.ts
@@ -1,4 +1,8 @@
-import { ReceiptType, UserQueryFilters } from "src/@generated/graphql";
+import {
+  ReceiptType,
+  SettleRemainingType,
+  UserQueryFilters,
+} from "src/@generated/graphql";
 
 export default {
   createUser: "Create new user",
@@ -141,6 +145,7 @@ export default {
     problemsError: "Could not report problems for all the copies.",
     returnAndDonate: "Return money and donate books",
     returnEverything: "Return money and books ({0} €)",
+    cashOnly: "Return cash only ({0} €)",
     confirms: {
       disclaimer:
         "You won't be able to cancel this action from the pay-off dialog. Do you wish to proceed?",
@@ -158,18 +163,36 @@ export default {
           "You are repaying this copy of the book to its owner customer. | You are repaying these copies of the book(s) to their owner customer.",
         confirmLabel: "Reimburse book | Reimburse books",
       },
-      returnAndDonate: {
-        disclaimer:
-          "The books in the list below will be donated by the customer to Mercatino del Libro. You will not be able to cancel this action. Do you wish to proceed?",
-        tableTitle: "Books Donated to the Mercatino",
-        buttonText: "Return money and donate books ({0} €)",
+      cashOnly: {
+        title: "Return cash only",
+        message:
+          "The sold books will be marked as settled, but the copies in stock that are owned by the selected customer will remain available for purchase. You will not be able to cancel this action. Do you wish to proceed?",
+        saveLabel: "Return cash ({0} €)",
       },
-      returnEverything: {
-        title: "Return money and books",
-        disclaimer:
-          "The books in the list below will be returned to the customer as they are the legitimate owner. You will not be able to cancel this action. Do you wish to proceed?",
-        tableTitle: "Books in return",
-      },
+      bulk: {
+        DONATE: {
+          title: "Return money and donate books",
+          disclaimer:
+            "The books in the list below will be donated by the customer to Mercatino del Libro. You will not be able to cancel this action. Do you wish to proceed?",
+          tableTitle: "Books Donated to the Mercatino",
+          saveLabel: "Return money and donate books ({0} €)",
+        },
+        RETURN: {
+          title: "Return money and books",
+          disclaimer:
+            "The books in the list below will be returned to the customer as they are the legitimate owner. You will not be able to cancel this action. Do you wish to proceed?",
+          tableTitle: "Books in return",
+          saveLabel: "Return money and books ({0} €)",
+        },
+      } satisfies Record<
+        Exclude<SettleRemainingType, "CASH_ONLY">,
+        {
+          title: string;
+          disclaimer: string;
+          tableTitle: string;
+          saveLabel: string;
+        }
+      >,
       confirmError: "Could not finish the settlement of the selected customer.",
     },
   },

--- a/packages/client/src/i18n/en-US/manage-users.ts
+++ b/packages/client/src/i18n/en-US/manage-users.ts
@@ -143,7 +143,7 @@ export default {
       reimburse: "Reimburse",
     },
     problemsError: "Could not report problems for all the copies.",
-    returnAndDonate: "Return money and donate books",
+    returnAndDonate: "Return money and donate books ({0} €)",
     returnEverything: "Return money and books ({0} €)",
     cashOnly: "Return cash only ({0} €)",
     confirms: {

--- a/packages/client/src/i18n/en-US/warehouse.ts
+++ b/packages/client/src/i18n/en-US/warehouse.ts
@@ -30,5 +30,6 @@ export default {
     sold: "Sold",
     inStock: "In Stock",
     reimbursed: "Reimbursed",
+    settled: "Sold and Settled",
   } satisfies Record<BookCopyStatus | "inStock", string>,
 };

--- a/packages/client/src/i18n/it/manage-users.ts
+++ b/packages/client/src/i18n/it/manage-users.ts
@@ -1,4 +1,8 @@
-import { ReceiptType, UserQueryFilters } from "src/@generated/graphql";
+import {
+  ReceiptType,
+  SettleRemainingType,
+  UserQueryFilters,
+} from "src/@generated/graphql";
 
 export default {
   createUser: "Crea nuovo utente",
@@ -144,6 +148,7 @@ export default {
       "Non è stato possibile segnalare il problema per tutte le copie.",
     returnAndDonate: "Restituisci contanti e dona libri",
     returnEverything: "Restituisci contanti e libri ({0} €)",
+    cashOnly: "Restituisci solo contanti ({0} €)",
     confirms: {
       disclaimer:
         "Non potrai annullare questa azione dal dialog di liquidazione. Vuoi procedere?",
@@ -160,18 +165,36 @@ export default {
           "Stai rimborsando questa copia del libro al cliente proprietario. | Stai rimborsando queste copie del/i libro/i al cliente proprietario.",
         confirmLabel: "Rimborsa libro | Rimborsa libri",
       },
-      returnAndDonate: {
-        disclaimer:
-          "I libri nella lista sottostante saranno donati dal cliente al Mercatino del Libro. Non potrai annullare questa azione. Vuoi procedere?",
-        tableTitle: "Libri Donati al Mercatino",
-        buttonText: "Restituisci contanti e dona libri ({0} €)",
+      cashOnly: {
+        title: "Restituisci solo contanti",
+        message:
+          "I libri venduti verranno contrassegnati come liquidati, ma le copie in magazzino che sono di proprietà del cliente selezionato rimarranno disponibili per l'acquisto. Non potrai annullare questa azione. Vuoi procedere?",
+        saveLabel: "Restituisci contanti ({0} €)",
       },
-      returnEverything: {
-        title: "Restituisci contanti e libri",
-        disclaimer:
-          "I libri nella lista sottostante saranno restituiti al cliente in quanto legittimo proprietario. Non potrai annullare questa azione. Vuoi procedere?",
-        tableTitle: "Libri in restituzione",
-      },
+      bulk: {
+        DONATE: {
+          title: "Restituisci contanti e dona libri",
+          disclaimer:
+            "I libri nella lista sottostante saranno donati dal cliente al Mercatino del Libro. Non potrai annullare questa azione. Vuoi procedere?",
+          tableTitle: "Libri Donati al Mercatino",
+          saveLabel: "Restituisci contanti e dona libri ({0} €)",
+        },
+        RETURN: {
+          title: "Restituisci contanti e libri",
+          disclaimer:
+            "I libri nella lista sottostante saranno restituiti al cliente in quanto legittimo proprietario. Non potrai annullare questa azione. Vuoi procedere?",
+          tableTitle: "Libri in restituzione",
+          saveLabel: "Restituisci contanti e libri ({0} €)",
+        },
+      } satisfies Record<
+        Exclude<SettleRemainingType, "CASH_ONLY">,
+        {
+          title: string;
+          disclaimer: string;
+          tableTitle: string;
+          saveLabel: string;
+        }
+      >,
       confirmError:
         "Non è stato possibile terminare la liquidazione del cliente selezionato.",
     },

--- a/packages/client/src/i18n/it/manage-users.ts
+++ b/packages/client/src/i18n/it/manage-users.ts
@@ -146,7 +146,7 @@ export default {
     },
     problemsError:
       "Non è stato possibile segnalare il problema per tutte le copie.",
-    returnAndDonate: "Restituisci contanti e dona libri",
+    returnAndDonate: "Restituisci contanti e dona libri ({0} €)",
     returnEverything: "Restituisci contanti e libri ({0} €)",
     cashOnly: "Restituisci solo contanti ({0} €)",
     confirms: {

--- a/packages/client/src/i18n/it/warehouse.ts
+++ b/packages/client/src/i18n/it/warehouse.ts
@@ -30,5 +30,6 @@ export default {
     sold: "Venduto",
     inStock: "In Magazzino",
     reimbursed: "Rimborsato",
+    settled: "Venduto e Liquidato",
   } satisfies Record<BookCopyStatus | "inStock", string>,
 };

--- a/packages/server/src/modules/user/user.args.ts
+++ b/packages/server/src/modules/user/user.args.ts
@@ -155,7 +155,8 @@ export class UpdateUserPayload extends IntersectionType(
 
 export enum SettleRemainingType {
   RETURN = "RETURN",
-  REFUND = "REFUND",
+  DONATE = "DONATE",
+  CASH_ONLY = "CASH ONLY",
 }
 registerEnumType(SettleRemainingType, {
   name: "SettleRemainingType",

--- a/packages/server/src/modules/user/user.resolver.ts
+++ b/packages/server/src/modules/user/user.resolver.ts
@@ -889,39 +889,45 @@ export class UserResolver {
         },
       });
 
-      const returnableCopies = bookCopies.filter(
-        ({ sales, returnedAt, donatedAt, reimbursedAt }) =>
-          returnedAt === null &&
-          donatedAt === null &&
-          reimbursedAt === null &&
-          sales.every(({ refundedAt }) => refundedAt !== null),
-      );
-      if (returnableCopies.length > 0) {
-        await prisma.bookCopy.updateMany({
-          where: {
-            id: {
-              in: returnableCopies.map(({ id }) => id),
+      if (remainingType !== SettleRemainingType.CASH_ONLY) {
+        const returnableCopies = bookCopies.filter(
+          ({ sales, returnedAt, donatedAt, reimbursedAt }) =>
+            returnedAt === null &&
+            donatedAt === null &&
+            reimbursedAt === null &&
+            sales.every(({ refundedAt }) => refundedAt !== null),
+        );
+        if (returnableCopies.length > 0) {
+          await prisma.bookCopy.updateMany({
+            where: {
+              id: {
+                in: returnableCopies.map(({ id }) => id),
+              },
             },
-          },
-          data: {
-            ...(remainingType === SettleRemainingType.RETURN
-              ? {
-                  returnedAt: new Date(),
-                  returnedById: operator.id,
-                }
-              : {
-                  donatedAt: new Date(),
-                  donatedById: operator.id,
-                }),
-          },
-        });
+            data: {
+              ...(remainingType === SettleRemainingType.RETURN
+                ? {
+                    returnedAt: new Date(),
+                    returnedById: operator.id,
+                  }
+                : {
+                    donatedAt: new Date(),
+                    donatedById: operator.id,
+                  }),
+            },
+          });
+        }
       }
 
       // Settle all non-settled book copies
       await prisma.bookCopy.updateMany({
         where: {
           id: {
-            in: bookCopies.map(({ id }) => id),
+            in: bookCopies
+              .filter(({ sales }) =>
+                sales.some(({ refundedAt }) => refundedAt === null),
+              )
+              .map(({ id }) => id),
           },
         },
         data: {


### PR DESCRIPTION
fixes #168

## What it does
This feature adds a new button to the payoff dialog actions to return the money of the unsettled sold books without returning/changing ownership of the books of the customer that are still in stock.

## How to test it
From the users management page, click on the checkout button for a user with sold books, then press the button to return cash only

### Additional notes
The label for the confirmation dialog may need further checks on the wording