### PR TITLE
fix(client+server): allow delegate for adults

### DIFF
--- a/packages/client/src/components/manage-users/edit-user-details-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-details-dialog.vue
@@ -236,6 +236,7 @@ import {
   mdiInformationOutline,
 } from "@quasar/extras/mdi-v7";
 import { formatDate } from "@vueuse/core";
+import { omit } from "lodash-es";
 import { Notify, useDialogPluginComponent } from "quasar";
 import { ref } from "vue";
 import { useI18n } from "vue-i18n";
@@ -280,7 +281,9 @@ const birthDate = ref(
 );
 const newUserData = ref(
   userData
-    ? ({ ...userData } satisfies UpdateUserPayload)
+    ? // Avoid sending "emailVerified" when updating user data
+      // That field can only be updated on the server and won't be accepted by the user update call
+      ({ ...omit(userData, ["emailVerified"]) } satisfies UpdateUserPayload)
     : ({
         retailLocationId: selectedLocation.value.id,
         email: "",

--- a/packages/client/src/helpers/rules.ts
+++ b/packages/client/src/helpers/rules.ts
@@ -172,13 +172,10 @@ export const allowOnlyIntegerNumbers: ValidationRule<string | number | null> = (
 const getAge = (birthDate: string): number =>
   Math.trunc(date.getDateDiff(new Date(), new Date(birthDate), "days") / 365);
 
-export const emptyRule: ValidationRule<string | null> = (value) =>
-  !value?.length || value.length === 0 || t("validators.noDelegateForAdult");
-
 export const requireIfUnderage = (
   birthDate?: string | null,
 ): ValidationRule<string | null> =>
-  !birthDate || getAge(birthDate) >= 18 ? emptyRule : requiredRule;
+  !birthDate || getAge(birthDate) >= 18 ? () => true : requiredRule;
 
 // ---------- ---------- ----------
 // Next fields are not imported in other files but we need to leave these so in the future we can abstract these in a package

--- a/packages/client/src/i18n/en-US/validators.ts
+++ b/packages/client/src/i18n/en-US/validators.ts
@@ -24,5 +24,4 @@ export default {
   nonValidISBN: "The ISBN is not valid",
   numberBetweenValues: "The value must be a number between {min} and {max}",
   onlyIntegers: "The value must be a whole number",
-  noDelegateForAdult: "An adult user cannot have a delegate",
 };

--- a/packages/client/src/i18n/it/validators.ts
+++ b/packages/client/src/i18n/it/validators.ts
@@ -25,5 +25,4 @@ export default {
   numberBetweenValues:
     "Il valore deve essere un numero compreso tra {min} e {max}",
   onlyIntegers: "Il valore deve essere un numero intero",
-  noDelegateForAdult: "Un utente maggiorenne non può avere un delegato",
 };

--- a/packages/server/src/modules/auth/auth.resolver.ts
+++ b/packages/server/src/modules/auth/auth.resolver.ts
@@ -73,11 +73,6 @@ export class AuthResolver {
     birthDate.setFullYear(birthDate.getFullYear() + 18);
     const isAdult = Date.now() - birthDate.getTime() >= 0;
 
-    if (isAdult && payload.delegate) {
-      throw new UnprocessableEntityException(
-        "An adult user cannot have a delegate.",
-      );
-    }
     if (!isAdult && !payload.delegate) {
       throw new UnprocessableEntityException(
         "An underaged user must have a delegate.",


### PR DESCRIPTION
Fixes #99

## What it does
This fix removes the check that disallowed adult customers to add a delegate on registration/update

## How to test it
Register an adult user and specify a delegate
Modify the data of an adult user adding a delegate