### PR TITLE
182 - feat(server+client): Brevo newsletter contacts sync

### DIFF
--- a/packages/client/quasar.config.js
+++ b/packages/client/quasar.config.js
@@ -254,6 +254,10 @@ module.exports = configure(function (ctx) {
           changeOrigin: true,
           target: process.env.GRAPHQL_DOMAIN,
         },
+        "/users": {
+          changeOrigin: true,
+          target: process.env.GRAPHQL_DOMAIN,
+        },
       },
     },
 

--- a/packages/client/src-pwa/custom-service-worker.ts
+++ b/packages/client/src-pwa/custom-service-worker.ts
@@ -41,6 +41,7 @@ if (process.env.PROD) {
           /auth\/*/,
           /receipts\/*/,
           /location\/*/,
+          /users\/*/,
         ],
       },
     ),

--- a/packages/client/src/components/settings-dialog.ts
+++ b/packages/client/src/components/settings-dialog.ts
@@ -1,0 +1,6 @@
+import { RetailLocationSettingsFragment } from "src/services/retail-location.graphql";
+
+export type SettingsDialogProps = Omit<
+  RetailLocationSettingsFragment,
+  "__typename"
+> & { retailLocationId: string };

--- a/packages/client/src/components/settings-dialog.vue
+++ b/packages/client/src/components/settings-dialog.vue
@@ -54,6 +54,18 @@
           <q-checkbox v-model="newSettings.payOffEnabled" color="primary" />
           {{ t("general.settings.payOffEnabled") }}
         </span>
+
+        <span>
+          {{ t("general.settings.downloadUserList") }}
+
+          <q-btn
+            v-if="hasAdminRole"
+            :label="t('common.downloadFile')"
+            class="q-ml-md"
+            color="accent"
+            @click="getUsersCSV()"
+          />
+        </span>
       </q-card-section>
 
       <template #card-actions="{ uniqueFormId }">
@@ -151,5 +163,16 @@ function confirmReset() {
   }).onOk(() => {
     onDialogOK({ type: "reset" });
   });
+}
+
+const { getJwtHeader } = useAuthService();
+
+async function getUsersCSV() {
+  const headers = getJwtHeader();
+  const response = await fetch("/users/export-csv", { headers });
+  const blob = await response.blob();
+
+  const dataUrl = URL.createObjectURL(blob);
+  window.open(dataUrl, "_blank");
 }
 </script>

--- a/packages/client/src/components/settings-dialog.vue
+++ b/packages/client/src/components/settings-dialog.vue
@@ -60,7 +60,7 @@
 
           <q-btn
             v-if="hasAdminRole"
-            :label="t('common.downloadFile')"
+            :label="t('common.download')"
             class="q-ml-md"
             color="accent"
             @click="getUsersCSV()"
@@ -99,10 +99,11 @@
 
 <script setup lang="ts">
 import { mdiInformationOutline } from "@quasar/extras/mdi-v7";
-import { Dialog, useDialogPluginComponent } from "quasar";
+import { Notify, Dialog, useDialogPluginComponent, exportFile } from "quasar";
 import { reactive } from "vue";
 import { useI18n } from "vue-i18n";
 import KDialogFormCard from "src/components/k-dialog-form-card.vue";
+import { notifyError } from "src/helpers/error-messages";
 import {
   allowOnlyIntegerNumbers,
   nonNegativeNumberRule,
@@ -110,8 +111,9 @@ import {
 import { SettingsUpdate } from "src/models/book";
 import { useAuthService } from "src/services/auth";
 import { RetailLocationSettingsFragment } from "src/services/retail-location.graphql";
+import { type SettingsDialogProps } from "./settings-dialog";
 
-const props = defineProps<Omit<RetailLocationSettingsFragment, "__typename">>();
+const props = defineProps<SettingsDialogProps>();
 
 defineEmits(useDialogPluginComponent.emitsObject);
 
@@ -169,10 +171,36 @@ const { getJwtHeader } = useAuthService();
 
 async function getUsersCSV() {
   const headers = getJwtHeader();
-  const response = await fetch("/users/export-csv", { headers });
+  const response = await fetch(`/users/export-csv/${props.retailLocationId}`, {
+    headers,
+  });
+
+  if (!response.ok) {
+    const { message } = (await response.json()) as {
+      message: string;
+      statusCode: number;
+    };
+    console.error(message);
+    notifyError(message);
+    return;
+  }
+
   const blob = await response.blob();
 
-  const dataUrl = URL.createObjectURL(blob);
-  window.open(dataUrl, "_blank");
+  const result = exportFile(
+    `${props.retailLocationId}-ilmercatinodellibro-users-export.csv`,
+    blob,
+  );
+
+  if (result !== true) {
+    console.error(result);
+    notifyError(t("general.settings.downloadUserListFailed"));
+    return;
+  }
+
+  Notify.create({
+    type: "positive",
+    message: t("general.settings.downloadUserListSuccess"),
+  });
 }
 </script>

--- a/packages/client/src/i18n/en-US/general.ts
+++ b/packages/client/src/i18n/en-US/general.ts
@@ -83,6 +83,8 @@ export default {
       "You are performing the reset of all the system data to prepare the software for the following year's activities. Do you wish to proceed?",
     resetButton: "Perform annual reset",
     resetConfirmButton: "Perform reset",
+    downloadUserList:
+      "Download the list of users with verified email address in a CSV file",
   },
   role: "Role",
   rolesAndPermissions: {

--- a/packages/client/src/i18n/en-US/general.ts
+++ b/packages/client/src/i18n/en-US/general.ts
@@ -85,6 +85,9 @@ export default {
     resetConfirmButton: "Perform reset",
     downloadUserList:
       "Download the list of users with verified email address in a CSV file",
+    downloadUserListSuccess: "The user list will be downloaded shortly",
+    downloadUserListFailed:
+      "Could not download the user list. Please contact the support.",
   },
   role: "Role",
   rolesAndPermissions: {

--- a/packages/client/src/i18n/en-US/index.ts
+++ b/packages/client/src/i18n/en-US/index.ts
@@ -83,7 +83,7 @@ export default {
 
     noData: "No data available",
 
-    downloadFile: "Download file",
+    download: "Download",
   },
 
   roleMap: {

--- a/packages/client/src/i18n/en-US/index.ts
+++ b/packages/client/src/i18n/en-US/index.ts
@@ -82,6 +82,8 @@ export default {
     notConnected: "Not Connected",
 
     noData: "No data available",
+
+    downloadFile: "Download file",
   },
 
   roleMap: {

--- a/packages/client/src/i18n/it/general.ts
+++ b/packages/client/src/i18n/it/general.ts
@@ -85,6 +85,10 @@ export default {
     resetConfirmButton: "Effettua reset",
     downloadUserList:
       "Scarica la lista degli utenti con e-mail verificata in un file CSV",
+    downloadUserListSuccess:
+      "Il download della lista degli utenti inizierà a breve",
+    downloadUserListFailed:
+      "Non è stato possibile scaricare la lista degli utenti. Contattate il supporto tecnico.",
   },
   role: "Ruolo",
   rolesAndPermissions: {

--- a/packages/client/src/i18n/it/general.ts
+++ b/packages/client/src/i18n/it/general.ts
@@ -83,6 +83,8 @@ export default {
       "Stai effettuando il reset di tutti i dati di sistema per predisporre il software alle attività dell'anno successivo. Vuoi procedere?",
     resetButton: "Effettua reset annuale",
     resetConfirmButton: "Effettua reset",
+    downloadUserList:
+      "Scarica la lista degli utenti con e-mail verificata in un file CSV",
   },
   role: "Ruolo",
   rolesAndPermissions: {

--- a/packages/client/src/i18n/it/index.ts
+++ b/packages/client/src/i18n/it/index.ts
@@ -84,6 +84,8 @@ export default {
     notConnected: "Non Connesso",
 
     noData: "Nessun dato disponibile",
+
+    downloadFile: "Scarica file",
   },
 
   roleMap: {

--- a/packages/client/src/i18n/it/index.ts
+++ b/packages/client/src/i18n/it/index.ts
@@ -85,7 +85,7 @@ export default {
 
     noData: "Nessun dato disponibile",
 
-    downloadFile: "Scarica file",
+    download: "Scarica",
   },
 
   roleMap: {

--- a/packages/client/src/layouts/authenticated-layout.vue
+++ b/packages/client/src/layouts/authenticated-layout.vue
@@ -502,6 +502,7 @@ import { useI18n } from "vue-i18n";
 import { setLanguage } from "src/boot/i18n";
 import AppDrawer from "src/components/app-drawer.vue";
 import HeaderBar from "src/components/header-bar.vue";
+import { type SettingsDialogProps } from "src/components/settings-dialog";
 import SettingsDialog from "src/components/settings-dialog.vue";
 import { provideHeaderActions } from "src/composables/header-features/use-header-actions";
 import { useLateralDrawer } from "src/composables/use-lateral-drawer";
@@ -513,7 +514,6 @@ import { useAuthService, useLogoutMutation } from "src/services/auth";
 import { useRetailLocationService } from "src/services/retail-location";
 import {
   RetailLocationFragmentDoc,
-  RetailLocationSettingsFragment,
   useResetRetailLocationMutation,
   useUpdateRetailLocationSettingsMutation,
 } from "src/services/retail-location.graphql";
@@ -575,7 +575,8 @@ function openSettings() {
       sellRate: selectedLocation.value.sellRate,
       registrationEnabled: selectedLocation.value.registrationEnabled,
       payOffEnabled: selectedLocation.value.payOffEnabled,
-    } satisfies RetailLocationSettingsFragment,
+      retailLocationId: selectedLocation.value.id,
+    } satisfies SettingsDialogProps,
   }).onOk(async (payload: SettingsUpdate) => {
     if (payload.type === "save") {
       try {

--- a/packages/server/src/modules/retail-location/retail-location.helpers.ts
+++ b/packages/server/src/modules/retail-location/retail-location.helpers.ts
@@ -1,0 +1,48 @@
+import { Prisma, Role } from "@prisma/client";
+
+export function getPrismaRetailLocationFilters(retailLocationId: string) {
+  const retailLocationFilter = {
+    book: {
+      retailLocationId,
+    },
+  };
+
+  const notAdminUser = {
+    memberships: {
+      none: {
+        // An admin in a retail location could possibly be a normal user in another one
+        retailLocationId,
+        role: Role.ADMIN,
+      },
+    },
+  } satisfies Prisma.UserWhereInput;
+
+  const activeUsersFilter = {
+    OR: [
+      // Requested at least one book
+      {
+        requestedBooks: {
+          some: {
+            ...retailLocationFilter,
+            deletedAt: null,
+          },
+        },
+      },
+      // Gave in at least one book
+      {
+        bookCopies: {
+          some: {
+            ...retailLocationFilter,
+          },
+        },
+      },
+    ],
+    ...notAdminUser,
+  } satisfies Prisma.UserWhereInput;
+
+  return {
+    retailLocationFilter,
+    notAdminUser,
+    activeUsersFilter,
+  };
+}

--- a/packages/server/src/modules/retail-location/retail-location.resolver.ts
+++ b/packages/server/src/modules/retail-location/retail-location.resolver.ts
@@ -7,6 +7,7 @@ import { RetailLocation } from "src/@generated/retail-location";
 import { AuthService } from "src/modules/auth/auth.service";
 import { CurrentUser } from "src/modules/auth/decorators/current-user.decorator";
 import { Input } from "src/modules/auth/decorators/input.decorator";
+import { getPrismaRetailLocationFilters } from "src/modules/retail-location/retail-location.helpers";
 import {
   UpdateRetailLocationInfoInput,
   UpdateRetailLocationSettingsInput,
@@ -233,21 +234,8 @@ export class RetailLocationResolver {
       message: STATISTICS_FORBIDDEN_MESSAGE,
     });
 
-    const retailLocationFilter = {
-      book: {
-        retailLocationId,
-      },
-    };
-
-    const notAdminUser = {
-      memberships: {
-        none: {
-          // An admin in a retail location could possibly be a normal user in another one
-          retailLocationId,
-          role: Role.ADMIN,
-        },
-      },
-    } satisfies Prisma.UserWhereInput;
+    const { retailLocationFilter, notAdminUser, activeUsersFilter } =
+      getPrismaRetailLocationFilters(retailLocationId);
 
     const getBooksCopiesCount = this.prisma.bookCopy.count({
       where: retailLocationFilter,
@@ -377,29 +365,6 @@ export class RetailLocationResolver {
         deletedAt: null,
       },
     });
-
-    const activeUsersFilter = {
-      OR: [
-        // Requested at least one book
-        {
-          requestedBooks: {
-            some: {
-              ...retailLocationFilter,
-              deletedAt: null,
-            },
-          },
-        },
-        // Gave in at least one book
-        {
-          bookCopies: {
-            some: {
-              ...retailLocationFilter,
-            },
-          },
-        },
-      ],
-      ...notAdminUser,
-    } satisfies Prisma.UserWhereInput;
 
     const getActiveUsersCount = this.prisma.user.count({
       where: activeUsersFilter,

--- a/packages/server/src/modules/user/user.controller.ts
+++ b/packages/server/src/modules/user/user.controller.ts
@@ -1,60 +1,83 @@
-import { createReadStream, writeFileSync } from "fs";
-import { join } from "path";
-import { Controller, Get, Header, StreamableFile } from "@nestjs/common";
+import { createReadStream, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  Controller,
+  Get,
+  Header,
+  Inject,
+  Param,
+  StreamableFile,
+  UnprocessableEntityException,
+} from "@nestjs/common";
 import { Role, type User } from "@prisma/client";
+import { upperCase } from "lodash";
+import { RootConfiguration, rootConfiguration } from "src/config/root";
 import { AuthService } from "src/modules/auth/auth.service";
 import { CurrentUser } from "src/modules/auth/decorators/current-user.decorator";
 import { PrismaService } from "src/modules/prisma/prisma.service";
+import { getPrismaRetailLocationFilters } from "src/modules/retail-location/retail-location.helpers";
 
-const contactsCsvFilePath = "storage/tmp/CONTACTS_LIST.csv";
+const CONTACTS_CSV_FILE_PATH = "./tmp/user_list.csv";
 
 @Controller("users")
 export class UserController {
   constructor(
     private readonly prisma: PrismaService,
     private readonly authService: AuthService,
+    @Inject(rootConfiguration.KEY)
+    private readonly rootConfig: RootConfiguration,
   ) {}
 
-  @Get("export-csv")
+  @Get("export-csv/:id")
   @Header("Content-Type", "text/csv")
-  async getUsersCSV(@CurrentUser() currentUser: User) {
+  async getUsersCSV(
+    @Param("id") retailLocationId: string,
+    @CurrentUser() currentUser: User,
+  ) {
     await this.authService.assertMembership({
       userId: currentUser.id,
       message: "Forbidden access",
       role: Role.ADMIN,
     });
 
+    const { activeUsersFilter } =
+      getPrismaRetailLocationFilters(retailLocationId);
+
     const users = await this.prisma.user.findMany({
-      where: { emailVerified: true },
-      distinct: "email",
+      where: { emailVerified: true, ...activeUsersFilter },
       select: {
-        id: true,
         firstname: true,
-        email: true,
         lastname: true,
-        locale: true,
+        email: true,
+        phoneNumber: true,
       },
     });
 
-    let csvBody = users
-      .map((user) => {
-        const userDataCsvRow = Object.values(user)
-          .map((value) => value ?? "null")
-          .join(",");
+    if (users.length === 0) {
+      throw new UnprocessableEntityException(
+        "No active users found for the specified retail location.",
+      );
+    }
 
-        return userDataCsvRow;
-      })
+    const csvHeader = Object.keys(users[0])
+      .map((value) => upperCase(value))
+      .join(",");
+    const csvBody = users
+      .map((user) =>
+        Object.values(user)
+          // Wrap values in double quotes to handle special characters
+          .map((value) => `"${value}"`)
+          .join(","),
+      )
       .join("\n");
 
-    const csvHeader = Object.keys(users[0]).join(",");
-    csvBody = `${csvHeader}\n${csvBody}`;
+    const filePath = resolve(
+      this.rootConfig.storagePath,
+      CONTACTS_CSV_FILE_PATH,
+    );
 
-    writeFileSync(contactsCsvFilePath, csvBody);
+    writeFileSync(filePath, `${csvHeader}\n${csvBody}`);
 
-    const file = createReadStream(join(process.cwd(), contactsCsvFilePath));
-
-    return new StreamableFile(file, {
-      type: "text/csv",
-    });
+    return new StreamableFile(createReadStream(filePath));
   }
 }

--- a/packages/server/src/modules/user/user.controller.ts
+++ b/packages/server/src/modules/user/user.controller.ts
@@ -1,0 +1,60 @@
+import { createReadStream, writeFileSync } from "fs";
+import { join } from "path";
+import { Controller, Get, Header, StreamableFile } from "@nestjs/common";
+import { Role, type User } from "@prisma/client";
+import { AuthService } from "src/modules/auth/auth.service";
+import { CurrentUser } from "src/modules/auth/decorators/current-user.decorator";
+import { PrismaService } from "src/modules/prisma/prisma.service";
+
+const contactsCsvFilePath = "storage/tmp/CONTACTS_LIST.csv";
+
+@Controller("users")
+export class UserController {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly authService: AuthService,
+  ) {}
+
+  @Get("export-csv")
+  @Header("Content-Type", "text/csv")
+  async getUsersCSV(@CurrentUser() currentUser: User) {
+    await this.authService.assertMembership({
+      userId: currentUser.id,
+      message: "Forbidden access",
+      role: Role.ADMIN,
+    });
+
+    const users = await this.prisma.user.findMany({
+      where: { emailVerified: true },
+      distinct: "email",
+      select: {
+        id: true,
+        firstname: true,
+        email: true,
+        lastname: true,
+        locale: true,
+      },
+    });
+
+    let csvBody = users
+      .map((user) => {
+        const userDataCsvRow = Object.values(user)
+          .map((value) => value ?? "null")
+          .join(",");
+
+        return userDataCsvRow;
+      })
+      .join("\n");
+
+    const csvHeader = Object.keys(users[0]).join(",");
+    csvBody = `${csvHeader}\n${csvBody}`;
+
+    writeFileSync(contactsCsvFilePath, csvBody);
+
+    const file = createReadStream(join(process.cwd(), contactsCsvFilePath));
+
+    return new StreamableFile(file, {
+      type: "text/csv",
+    });
+  }
+}

--- a/packages/server/src/modules/user/user.module.ts
+++ b/packages/server/src/modules/user/user.module.ts
@@ -4,6 +4,7 @@ import { AuthModule } from "src/modules/auth/auth.module";
 import { AddAdminUserCommand } from "src/modules/user/add-admin-user.command";
 import { SeedUsersWithBooksCommand } from "src/modules/user/seed-users-with-books.command";
 import { UserAccountResolver } from "src/modules/user/user-account.resolver";
+import { UserController } from "src/modules/user/user.controller";
 import { PrismaModule } from "../prisma/prisma.module";
 import { UserResolver } from "./user.resolver";
 import { UserService } from "./user.service";
@@ -18,5 +19,6 @@ import { UserService } from "./user.service";
     SeedUsersWithBooksCommand,
   ],
   exports: [UserService],
+  controllers: [UserController],
 })
 export class UserModule {}


### PR DESCRIPTION
Fixes #182

## What it does
This feature adds a button to the Admin settings dialog's UI to download a CSV with the contact information for all the users with a verified email in the database, and also saves it in `packages/server/src/tmp`

## How to test it
Log in as admin, go to the settings panel and click on the button for downloading the CSV

### Additional notes
Potentially add the support for
- a blacklist
- an option for users to opt out
- ~~location based CSVs~~ (done by Callo)
- automated CSV upload to Brevo via their API