### PR TITLE
feat(server): fix reservation emails frequency

### DIFF
--- a/packages/server/src/cli.module.ts
+++ b/packages/server/src/cli.module.ts
@@ -1,0 +1,35 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { EventEmitterModule } from "@nestjs/event-emitter";
+import { authConfiguration } from "src/config/auth";
+import { brevoConfiguration } from "src/config/brevo";
+import { databaseConfiguration } from "src/config/database";
+import { emailConfiguration } from "src/config/email";
+import { queueConfiguration } from "src/config/queue";
+import { rootConfiguration } from "src/config/root";
+
+import { BookCliModule } from "src/modules/book/book-cli.module";
+import { UserCliModule } from "src/modules/user/user-cli.module";
+import { PrismaModule } from "./modules/prisma/prisma.module";
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      load: [
+        rootConfiguration,
+        authConfiguration,
+        databaseConfiguration,
+        emailConfiguration,
+        queueConfiguration,
+        brevoConfiguration,
+      ],
+      expandVariables: true,
+    }),
+    EventEmitterModule.forRoot(),
+    PrismaModule,
+    BookCliModule,
+    UserCliModule,
+  ],
+})
+export class CliModule {}

--- a/packages/server/src/commander.ts
+++ b/packages/server/src/commander.ts
@@ -1,10 +1,10 @@
 import { ConsoleLogger, Logger } from "@nestjs/common";
 import { CommandFactory } from "nest-commander";
-import { AppModule } from "src/app.module";
+import { CliModule } from "src/cli.module";
 
 async function bootstrap() {
   Logger.log("Mercatino del Libro Commands booting...", "Bootstrap");
-  await CommandFactory.run(AppModule, {
+  await CommandFactory.run(CliModule, {
     usePlugins: true,
     logger: new (class extends ConsoleLogger {
       log(message: string, context?: string) {

--- a/packages/server/src/modules/book-copy/book-copy.filters.ts
+++ b/packages/server/src/modules/book-copy/book-copy.filters.ts
@@ -1,0 +1,22 @@
+import type { Prisma } from "@prisma/client";
+
+export const noSalesFilter: Prisma.BookCopyWhereInput = {
+  sales: {
+    none: {
+      refundedAt: null,
+    },
+  },
+};
+export const noProblemsFilter: Prisma.BookCopyWhereInput = {
+  problems: {
+    none: {
+      resolvedAt: null,
+    },
+  },
+};
+
+export const availableBookCopyFilter: Prisma.BookCopyWhereInput = {
+  returnedAt: null,
+  donatedAt: null,
+  AND: [noSalesFilter, noProblemsFilter],
+};

--- a/packages/server/src/modules/book-copy/book-copy.resolver.ts
+++ b/packages/server/src/modules/book-copy/book-copy.resolver.ts
@@ -39,6 +39,7 @@ import {
   PaginatedBookCopiesQueryArgs,
   PaginatedBookCopyQueryResult,
 } from "./book-copy.args";
+import { availableBookCopyFilter } from "./book-copy.filters";
 import { BookCopyService } from "./book-copy.service";
 
 @Resolver(() => BookCopy)
@@ -336,35 +337,7 @@ export class BookCopyResolver {
       ...(includeCopyOrStatement
         ? {
             AND: [
-              ...(isAvailable
-                ? ([
-                    {
-                      problems: {
-                        every: {
-                          resolvedAt: {
-                            not: null,
-                          },
-                        },
-                      },
-                      OR: [
-                        {
-                          sales: {
-                            none: {},
-                          },
-                        },
-                        {
-                          sales: {
-                            every: {
-                              refundedAt: {
-                                not: null,
-                              },
-                            },
-                          },
-                        },
-                      ],
-                    },
-                  ] satisfies Prisma.BookCopyWhereInput[])
-                : []),
+              ...(isAvailable ? [availableBookCopyFilter] : []),
               ...(isSold
                 ? [
                     {

--- a/packages/server/src/modules/book-request/book-request.service.ts
+++ b/packages/server/src/modules/book-request/book-request.service.ts
@@ -1,6 +1,6 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import { EventEmitter2, OnEvent } from "@nestjs/event-emitter";
-import { Cron } from "@nestjs/schedule";
+import { Cron, CronExpression } from "@nestjs/schedule";
 import {
   Book,
   BookRequest,
@@ -9,6 +9,7 @@ import {
   RetailLocation,
 } from "@prisma/client";
 import { BookMeta } from "src/@generated";
+import { availableBookCopyFilter } from "src/modules/book-copy/book-copy.filters";
 import { NEW_NOTIFICATION_EVENT } from "src/modules/notification/notification.module";
 import { NewNotificationPayload } from "src/modules/notification/send-push-notification.listener";
 import { PrismaService } from "src/modules/prisma/prisma.service";
@@ -18,8 +19,39 @@ type RequestQueue = PrismaRequestQueue & {
   currentRequest: BookRequest;
 };
 
+/**
+ * The maximum daily amount of email sends that the SMTP service
+ * allows per day (currently two 1k packages)
+ */
+const DAILY_EMAIL_QUOTA = 2000;
+
+/**
+ * The maximum reserved amount of daily sends for authentication
+ * and receipts emails, must be less than {@link DAILY_EMAIL_QUOTA}
+ */
+const DAILY_AUTH_AND_RECEIPTS_EMAIL_QUOTA = 500;
+
+/**
+ * The time in minutes after which a newly inserted book copy
+ * or expired/deleted reservation should trigger a notification
+ * for the book being available for reservation
+ */
+const AVAILABILITY_COOLDOWN = 120;
+
+/** Maximum size for each batch of queues */
+const MAX_SENDS_PER_BATCH = 5;
+
+/** Interval between batches in seconds */
+const SECONDS_BETWEEN_BATCHES = 15;
+
+/** The daily cap of emails for newly reservable books */
+const DAILY_RESERVATION_EMAIL_QUOTA =
+  DAILY_EMAIL_QUOTA - DAILY_AUTH_AND_RECEIPTS_EMAIL_QUOTA;
+
 @Injectable()
 export class BookRequestService {
+  private readonly logger = new Logger(BookRequestService.name);
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly eventEmitter: EventEmitter2,
@@ -96,6 +128,22 @@ export class BookRequestService {
     }
   }
 
+  /** The current amount of reservation email sends remaining for the day */
+  private currentlyAvailableReservationEmails = DAILY_RESERVATION_EMAIL_QUOTA;
+
+  /**
+   * Every day at midnight, reset the currently available reservation
+   * emails counter to the daily quota
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  resetAvailableReservationEmails() {
+    this.logger.log(
+      `Resetting the reservation availability email daily cap to ${DAILY_RESERVATION_EMAIL_QUOTA} sends`,
+    );
+
+    this.currentlyAvailableReservationEmails = DAILY_RESERVATION_EMAIL_QUOTA;
+  }
+
   /**
    * The time in minutes after which a queue will be rechecked.
    * This value must respect the frequency of the `@Cron` handler
@@ -105,10 +153,58 @@ export class BookRequestService {
   // Every day at the start of every hour from 8 am to 9pm (included)
   @Cron("0 8-21 * * *")
   async handleRequestQueues() {
+    if (this.currentlyAvailableReservationEmails === 0) {
+      // No more emails are allowed from our SMTP service for the
+      // day so we stop advancing the queues until the next day
+      return;
+    }
+
+    this.logger.log(
+      `Cron job running updating book request queues, remaining emails for the day: ${this.currentlyAvailableReservationEmails}`,
+    );
+
+    const cooldownCutoff = new Date();
+    cooldownCutoff.setMinutes(
+      cooldownCutoff.getMinutes() - AVAILABILITY_COOLDOWN,
+    );
+
+    const maxNumberOfBatches =
+      (this.#queueProcessingInterval * 60) / SECONDS_BETWEEN_BATCHES;
+
     const queues = await this.prisma.requestQueue.findMany({
       where: {
         lastCheckedAt: {
           lte: this.#getProcessTickTime(),
+        },
+        book: {
+          OR: [
+            {
+              // If some copies have just been added, wait before notifying the client
+              // about them being available for reservation until the cooldown expires
+              copies: {
+                some: {
+                  createdAt: {
+                    lte: cooldownCutoff,
+                  },
+
+                  ...availableBookCopyFilter,
+                },
+              },
+            },
+            {
+              // If some reservations were just deleted or just expired, wait before
+              // processing them as contributing to the book being available for
+              // reservation until the cooldown expires
+              reservations: {
+                some: {
+                  OR: [
+                    { deletedAt: { lte: cooldownCutoff, not: null } },
+                    { expiresAt: { lte: cooldownCutoff } },
+                  ],
+                },
+              },
+            },
+          ],
         },
       },
       include: {
@@ -120,10 +216,46 @@ export class BookRequestService {
         },
         currentRequest: true,
       },
+      take: Math.min(
+        this.currentlyAvailableReservationEmails,
+        maxNumberOfBatches * MAX_SENDS_PER_BATCH,
+      ),
     });
 
-    for (const queue of queues) {
-      await this.#handleQueue(queue.bookId, queue);
+    if (queues.length === 0) {
+      this.logger.log("No queues to update");
+
+      return;
+    }
+
+    const numberOfBatches = Math.ceil(queues.length / MAX_SENDS_PER_BATCH);
+
+    for (let batchIndex = 0; batchIndex < numberOfBatches; batchIndex++) {
+      const startTime = Date.now();
+
+      const start = batchIndex * MAX_SENDS_PER_BATCH;
+      const end = start + MAX_SENDS_PER_BATCH;
+      const batch = queues.slice(start, end);
+
+      await Promise.all(batch.map((queue) => this.#handleQueue(queue)));
+
+      // If there are no more batches left, don't wait for any delay and just exit
+      if (batchIndex === numberOfBatches - 1) {
+        break;
+      }
+
+      const processingTime = Date.now() - startTime;
+
+      if (processingTime > SECONDS_BETWEEN_BATCHES * 1000) {
+        throw new Error(
+          "A batch of emails for available books took too long to process",
+        );
+      }
+
+      // Delay the next batch of sends to avoid rate limit errors from the SMTP service
+      await new Promise((resolve) =>
+        setTimeout(resolve, SECONDS_BETWEEN_BATCHES * 1000 - processingTime),
+      );
     }
   }
 
@@ -132,21 +264,28 @@ export class BookRequestService {
     return new Date(Date.now() - this.#queueProcessingInterval * minute);
   }
 
-  async #handleQueue(bookId: string, queue: RequestQueue) {
-    if (!queue.book.meta.isAvailable) {
+  async #handleQueue({
+    book,
+    bookId,
+    id: queueId,
+    currentRequest,
+  }: RequestQueue) {
+    if (!book.meta.isAvailable) {
       await this.prisma.requestQueue.delete({
-        where: { id: queue.id },
+        where: { id: queueId },
       });
       return;
     }
 
-    await this.#notifyUser(queue.currentRequest, queue.book);
+    await this.#notifyUser(currentRequest, book);
+
+    this.currentlyAvailableReservationEmails--;
 
     const nextRequest = await this.prisma.bookRequest.findFirst({
       where: {
         bookId,
-        id: { not: queue.currentRequest.id },
-        createdAt: { gte: queue.currentRequest.createdAt },
+        id: { not: currentRequest.id },
+        createdAt: { gte: currentRequest.createdAt },
         ...this.availableRequestFilter,
       },
       orderBy: {
@@ -155,7 +294,7 @@ export class BookRequestService {
     });
     if (!nextRequest) {
       await this.prisma.requestQueue.delete({
-        where: { id: queue.id },
+        where: { id: queueId },
       });
 
       return;

--- a/packages/server/src/modules/book-request/book-request.service.ts
+++ b/packages/server/src/modules/book-request/book-request.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { EventEmitter2, OnEvent } from "@nestjs/event-emitter";
-import { Cron, CronExpression } from "@nestjs/schedule";
+import { Cron } from "@nestjs/schedule";
 import {
   Book,
   BookRequest,
@@ -97,12 +97,13 @@ export class BookRequestService {
   }
 
   /**
-   * The time in minutes after which a queue should be rechecked.
-   * Don't forget to update the `@Cron` decorator when changing this value.
+   * The time in minutes after which a queue will be rechecked.
+   * This value must respect the frequency of the `@Cron` handler
    */
-  readonly #queueProcessingInterval = 30;
+  readonly #queueProcessingInterval = 60;
 
-  @Cron(CronExpression.EVERY_30_MINUTES)
+  // Every day at the start of every hour from 8 am to 9pm (included)
+  @Cron("0 8-21 * * *")
   async handleRequestQueues() {
     const queues = await this.prisma.requestQueue.findMany({
       where: {

--- a/packages/server/src/modules/book-request/book-request.service.ts
+++ b/packages/server/src/modules/book-request/book-request.service.ts
@@ -239,6 +239,13 @@ export class BookRequestService {
 
       await Promise.all(batch.map((queue) => this.#handleQueue(queue)));
 
+      this.logger.log(
+        `Processed batch ${batchIndex + 1} of ${numberOfBatches}`,
+      );
+      this.logger.log(
+        `Remaining emails for the day: ${this.currentlyAvailableReservationEmails}`,
+      );
+
       // If there are no more batches left, don't wait for any delay and just exit
       if (batchIndex === numberOfBatches - 1) {
         break;

--- a/packages/server/src/modules/book/book-cli.module.ts
+++ b/packages/server/src/modules/book/book-cli.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { ImportBooksCommand } from "src/modules/book/import-books.command";
+import { PrismaModule } from "../prisma/prisma.module";
+
+@Module({
+  imports: [PrismaModule, ConfigModule],
+  providers: [ImportBooksCommand],
+})
+export class BookCliModule {}

--- a/packages/server/src/modules/book/book.resolver.ts
+++ b/packages/server/src/modules/book/book.resolver.ts
@@ -15,6 +15,11 @@ import { BookCopy, BookMeta } from "src/@generated";
 import { Book } from "src/@generated/book";
 import { CurrentUser } from "src/modules/auth/decorators/current-user.decorator";
 import { BookUtility } from "src/modules/book/book-utility";
+import {
+  availableBookCopyFilter,
+  noProblemsFilter,
+  noSalesFilter,
+} from "src/modules/book-copy/book-copy.filters";
 import { Input } from "../auth/decorators/input.decorator";
 import { PrismaService } from "../prisma/prisma.service";
 import {
@@ -184,51 +189,6 @@ export class BookResolver {
       .meta();
   }
 
-  private readonly noSalesFilter: Prisma.BookCopyWhereInput[] = [
-    {
-      sales: {
-        none: {},
-      },
-    },
-    {
-      sales: {
-        every: {
-          refundedAt: {
-            not: null,
-          },
-        },
-      },
-    },
-  ];
-  private readonly noProblemsFilter: Prisma.BookCopyWhereInput[] = [
-    {
-      problems: {
-        none: {},
-      },
-    },
-    {
-      problems: {
-        every: {
-          resolvedAt: {
-            not: null,
-          },
-        },
-      },
-    },
-  ];
-  private readonly availableCopyFilter: Prisma.BookCopyWhereInput = {
-    returnedAt: null,
-    donatedAt: null,
-    AND: [
-      {
-        OR: this.noSalesFilter,
-      },
-      {
-        OR: this.noProblemsFilter,
-      },
-    ],
-  };
-
   @ResolveField(() => [BookCopy])
   async copies(
     @Root() book: Book,
@@ -239,7 +199,7 @@ export class BookResolver {
         where: { id: book.id },
       })
       .copies({
-        where: isAvailable ? this.availableCopyFilter : undefined,
+        where: isAvailable ? availableBookCopyFilter : undefined,
         orderBy: {
           code: "asc",
         },
@@ -301,22 +261,20 @@ export class BookResolver {
       bookRelationQuery("copies", {
         where: {
           bookId: book.id,
-          ...this.availableCopyFilter,
+          ...availableBookCopyFilter,
         },
       }),
       bookRelationQuery("copies", {
         where: {
           bookId: book.id,
-          OR: this.noProblemsFilter,
+          ...noProblemsFilter,
         },
       }),
       bookRelationQuery("copies", {
         where: {
           bookId: book.id,
           returnedAt: null,
-          NOT: {
-            OR: this.noSalesFilter,
-          },
+          NOT: noSalesFilter,
         },
       }),
       bookRelationQuery("requests", {

--- a/packages/server/src/modules/user/seed-users-with-books.command.ts
+++ b/packages/server/src/modules/user/seed-users-with-books.command.ts
@@ -1,6 +1,7 @@
 import { randomInt } from "crypto";
 import { faker } from "@faker-js/faker";
 import { Logger } from "@nestjs/common";
+import { EventEmitter2 } from "@nestjs/event-emitter";
 import {
   Book,
   BookCopy,
@@ -48,7 +49,10 @@ export class SeedUsersWithBooksCommand extends CommandRunner {
   private readonly logger = new Logger(SeedUsersWithBooksCommand.name);
   private readonly bookService = new BookCopyService();
 
-  constructor(private readonly prisma: PrismaService) {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly eventEmitter: EventEmitter2,
+  ) {
     super();
   }
 
@@ -305,6 +309,12 @@ export class SeedUsersWithBooksCommand extends CommandRunner {
             ),
             userId: buyer.id,
           })),
+      });
+
+      this.eventEmitter.emit("booksBecameAvailable", {
+        bookIds: availableRequests
+          .slice(ITEMS_TO_NOT_PROCESS_COUNT)
+          .map(({ bookId }) => bookId),
       });
 
       const reservations = await this.prisma.reservation.findMany({

--- a/packages/server/src/modules/user/seed-users-with-books.command.ts
+++ b/packages/server/src/modules/user/seed-users-with-books.command.ts
@@ -506,6 +506,14 @@ export class SeedUsersWithBooksCommand extends CommandRunner {
       },
     });
 
+    await this.prisma.requestQueue.deleteMany({
+      where: {
+        currentRequest: {
+          user: seedUserFilter,
+        },
+      },
+    });
+
     await this.prisma.bookRequest.deleteMany({
       where: {
         user: seedUserFilter,

--- a/packages/server/src/modules/user/user-cli.module.ts
+++ b/packages/server/src/modules/user/user-cli.module.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { BookRequestService } from "src/modules/book-request/book-request.service";
+import { AddAdminUserCommand } from "src/modules/user/add-admin-user.command";
+import { SeedUsersWithBooksCommand } from "src/modules/user/seed-users-with-books.command";
+import { PrismaModule } from "../prisma/prisma.module";
+
+@Module({
+  imports: [PrismaModule, ConfigModule],
+  providers: [
+    AddAdminUserCommand,
+    SeedUsersWithBooksCommand,
+    // TODO: this breaks module segregation, but it's needed to allow SeedUsersWithBooksCommand to generate RequestQueue
+    // We should refactor the "@OnEvent("booksBecameAvailable")" bit into a dedicated RequestQueue module and import that instead
+    BookRequestService,
+  ],
+})
+export class UserCliModule {}

--- a/packages/server/src/modules/user/user.module.ts
+++ b/packages/server/src/modules/user/user.module.ts
@@ -2,8 +2,6 @@ import { Module, forwardRef } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 import { AuthModule } from "src/modules/auth/auth.module";
 import { ReceiptModule } from "src/modules/receipt/receipt.module";
-import { AddAdminUserCommand } from "src/modules/user/add-admin-user.command";
-import { SeedUsersWithBooksCommand } from "src/modules/user/seed-users-with-books.command";
 import { UserAccountResolver } from "src/modules/user/user-account.resolver";
 import { PrismaModule } from "../prisma/prisma.module";
 import { UserResolver } from "./user.resolver";
@@ -16,13 +14,7 @@ import { UserService } from "./user.service";
     ConfigModule,
     ReceiptModule,
   ],
-  providers: [
-    UserResolver,
-    UserAccountResolver,
-    UserService,
-    AddAdminUserCommand,
-    SeedUsersWithBooksCommand,
-  ],
+  providers: [UserResolver, UserAccountResolver, UserService],
   exports: [UserService],
 })
 export class UserModule {}


### PR DESCRIPTION
Fixes #169

To test it:
- make sure the server env SMTP config is set to dev test Mailtrap sandbox
- optionally activate the push notifications by setting `PUSH_NOTIFICATIONS_DRIVER=local` in the server env
- change the constants at the top of `packages/server/src/modules/book-request/book-request.service.ts` to smaller numbers, like
```ts
const DAILY_EMAIL_QUOTA = 20;
const DAILY_AUTH_AND_RECEIPTS_EMAIL_QUOTA = 0;
const AVILABILITY_COOLDOWN = 0;

// mailtrap allows max 5 sends every 15 seconds
const MAX_SENDS_PER_BATCH = 5;
const SECONDS_BETWEEN_BATCHES = 15;
```
- change the `resetAvailableReservationEmails` cron to `"*/3 * * * *"` to make the "daily cycle" reset every 3 minutes
- change the `handleRequestQueues` cron frequency to `"* * * * *"` so it runs every minute, and update `#queueProcessingInterval` to 1 to reflect that
- open a shell on the server and run the command `pnpm seed-users-with-books -u 20` to seed 20 (you can raise this number for stress testing) users with available books and the relative requests, and populate the request queues
- start the dev server and check the email (plus optionally client web push notifications if you enabled them)

### Additional notes
The constants could be extracted into env configuration in the future