### PR TITLE
125 highlight selected user

### DIFF
--- a/packages/client/src/components/manage-users/cart-dialog.vue
+++ b/packages/client/src/components/manage-users/cart-dialog.vue
@@ -7,11 +7,7 @@
   >
     <k-dialog-card
       :class="isMobile ? 'card-actions-shadow' : ''"
-      :title="
-        $t('manageUsers.cartDialog.title', [
-          `${user.firstname} ${user.lastname}`,
-        ])
-      "
+      :title="$t('manageUsers.cartDialog.title', user)"
       size="fullscreen"
       @cancel="onDialogCancel"
     >

--- a/packages/client/src/components/manage-users/edit-user-books-movements-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-books-movements-dialog.vue
@@ -195,7 +195,7 @@ const title = computed(() =>
     props.type === "sold"
       ? "manageUsers.booksMovementsDialog.soldTitle"
       : "manageUsers.booksMovementsDialog.purchasedTitle",
-    [`${props.userData.firstname} ${props.userData.lastname}`],
+    props.userData,
   ),
 );
 

--- a/packages/client/src/components/manage-users/edit-user-requested-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-requested-dialog.vue
@@ -7,11 +7,7 @@
     <k-dialog-card
       :cancel-label="$t('common.close')"
       :no-actions="isMobile"
-      :title="
-        $t('manageUsers.requestedBooksDialog.title', [
-          `${userData.firstname} ${userData.lastname}`,
-        ])
-      "
+      :title="$t('manageUsers.requestedBooksDialog.title', userData)"
       size="fullscreen"
       @cancel="onDialogCancel"
     >

--- a/packages/client/src/components/manage-users/edit-user-reserved-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-reserved-dialog.vue
@@ -9,11 +9,7 @@
       size="fullscreen"
       :cancel-label="$t('common.close')"
       :no-actions="isMobile"
-      :title="
-        $t('manageUsers.reservedBooksDialog.title', [
-          `${userData.firstname} ${userData.lastname}`,
-        ])
-      "
+      :title="$t('manageUsers.reservedBooksDialog.title', userData)"
       @cancel="onDialogCancel"
     >
       <card-table-header @add-book="addReservationFromIsbn">

--- a/packages/client/src/components/manage-users/edit-user-stockdata-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-stockdata-dialog.vue
@@ -9,11 +9,7 @@
     <k-dialog-card
       :cancel-label="$t('common.close')"
       :no-actions="isMobile"
-      :title="
-        $t('manageUsers.inStockDialog.title', [
-          `${userData.firstname} ${userData.lastname}`,
-        ])
-      "
+      :title="$t('manageUsers.inStockDialog.title', userData)"
       size="fullscreen"
       @cancel="onDialogCancel"
     >

--- a/packages/client/src/components/manage-users/pay-off-user-dialog.vue
+++ b/packages/client/src/components/manage-users/pay-off-user-dialog.vue
@@ -7,11 +7,7 @@
     @hide="onDialogHide"
   >
     <k-dialog-card
-      :title="
-        $t('manageUsers.payOffUserDialog.title', [
-          `${user.firstname} ${user.lastname}`,
-        ])
-      "
+      :title="$t('manageUsers.payOffUserDialog.title', user)"
       @cancel="onDialogCancel"
     >
       <q-card-section

--- a/packages/client/src/components/manage-users/receipts-dialog.vue
+++ b/packages/client/src/components/manage-users/receipts-dialog.vue
@@ -1,7 +1,7 @@
 <template>
   <q-dialog ref="dialogRef" @hide="onDialogHide">
     <k-dialog-card
-      :title="t('manageUsers.receiptsDialog.title')"
+      :title="t('manageUsers.receiptsDialog.title', user)"
       size="md"
       @cancel="onDialogCancel"
     >

--- a/packages/client/src/i18n/en-US/manage-users.ts
+++ b/packages/client/src/i18n/en-US/manage-users.ts
@@ -68,7 +68,7 @@ export default {
   inStock: "In magazzino",
   searchHint: "Insert an ISBN code to add the book to the list",
   inStockDialog: {
-    title: "Books of {0} in Stock",
+    title: "Books of {firstname} {lastname} ({email}) in Stock",
     retrievableTooltip:
       "Includes the copies that are still present in stock, even if with problems or reserved",
     retrieveBtn: "Retrieve all the books in the list",
@@ -79,8 +79,8 @@ export default {
     },
   },
   booksMovementsDialog: {
-    purchasedTitle: "Books purchased by {0}",
-    soldTitle: "Books sold by {0}",
+    purchasedTitle: "Books purchased by {firstname} {lastname} ({email})",
+    soldTitle: "Books sold by {firstname} {lastname} ({email})",
     purchasedAt: "Purchased at",
     soldTo: "Sold to",
     purchasedBy: "Purchased by",
@@ -103,7 +103,7 @@ export default {
   },
   actions: "Actions",
   requestedBooksDialog: {
-    title: "Books requested by {0}",
+    title: "Books requested by {firstname} {lastname} ({email})",
     titleNoName: "Requested books",
     deleteAll: "Delete All",
     moveIntoReserved: "Move Available into Reserved",
@@ -111,7 +111,7 @@ export default {
     booksRequested: "",
   },
   reservedBooksDialog: {
-    title: "Books reserved by {0}",
+    title: "Books reserved by {firstname} {lastname} ({email})",
     deleteAllReserved: "Delete all Reserved Books",
     moveAllIntoCart: "Put Reserved and Available Books into the Cart",
     reservedIntoCart: "Put Reserved Books into the Cart",
@@ -126,7 +126,7 @@ export default {
     requestsReserved: "Reserved {0} copies of requested books.",
   },
   payOffUserDialog: {
-    title: "Check Out User {0}",
+    title: "Check Out User {firstname} {lastname} ({email})",
     soldBooksCountLabel: "Total of the User's Books Sold to Others",
     totalPayOffLabel: "Total Money Settleable to the User",
     totalCheckedOutLabel: "Total Settled to the User",
@@ -206,7 +206,7 @@ export default {
   iseeInfoTooltip:
     "Is this user entitled to the discount and does the total to be returned take it into account?",
   cartDialog: {
-    title: "Cart of {0}",
+    title: "Cart of {firstname} {lastname} ({email})",
     emptyCart: "Empty the cart",
     autoEmptyDisclaimer:
       "Remember: you cannot keep the available books stuck in the cart for too long, therefore it will automatically be emptied in: {0}",
@@ -228,7 +228,7 @@ export default {
     },
   },
   receiptsDialog: {
-    title: "Receipts",
+    title: "Receipts of {firstname} {lastname} ({email})",
     createdBy: "Created by",
     resend: "Send again",
     resendSuccess:

--- a/packages/client/src/i18n/it/manage-users.ts
+++ b/packages/client/src/i18n/it/manage-users.ts
@@ -70,7 +70,7 @@ export default {
   inStock: "In magazzino",
   searchHint: "Inserisci un codice ISBN per aggiungere il libro alla lista",
   inStockDialog: {
-    title: "Libri di {0} in Magazzino",
+    title: "Libri di {firstname} {lastname} ({email}) in Magazzino",
     retrievableTooltip:
       "Include le copie ancora presenti in magazzino, anche quelle con problemi o prenotate",
     retrieveBtn: "Ritira tutti i libri nella lista",
@@ -81,8 +81,8 @@ export default {
     },
   },
   booksMovementsDialog: {
-    purchasedTitle: "Libri acquistati da {0}",
-    soldTitle: "Libri venduti da {0}",
+    purchasedTitle: "Libri acquistati da {firstname} {lastname} ({email})",
+    soldTitle: "Libri venduti da {firstname} {lastname} ({email})",
     purchasedAt: "Acquistato il",
     soldTo: "Venduto a",
     purchasedBy: "Il venditore",
@@ -105,7 +105,7 @@ export default {
   },
   actions: "Azioni",
   requestedBooksDialog: {
-    title: "Libri richiesti da {0}",
+    title: "Libri richiesti da {firstname} {lastname} ({email})",
     titleNoName: "Libri Richiesti",
     deleteAll: "Elimina Tutti",
     moveIntoReserved: "Sposta i Disponibili nei Prenotati",
@@ -113,7 +113,7 @@ export default {
     booksRequested: "",
   },
   reservedBooksDialog: {
-    title: "Libri prenotati da {0}",
+    title: "Libri prenotati da {firstname} {lastname} ({email})",
     deleteAllReserved: "Elimina tutti i Prenotati",
     moveAllIntoCart: "Metti Prenotati e Disponibili nel Carrello",
     reservedIntoCart: "Metti i Prenotati nel Carrello",
@@ -128,7 +128,7 @@ export default {
     requestsReserved: "{0} copie di libri richiesti prenotate.",
   },
   payOffUserDialog: {
-    title: "Liquida Utente {0}",
+    title: "Liquida Utente {firstname} {lastname} ({email})",
     soldBooksCountLabel: "Totale Libri dell'Utente Venduti ad Altri",
     totalPayOffLabel: "Totale Liquidabile all'Utente",
     totalCheckedOutLabel: "Totale Liquidato all'Utente",
@@ -209,7 +209,7 @@ export default {
   iseeInfoTooltip:
     "Questo utente ha diritto allo sconto e il totale da rendere ne tiene conto?",
   cartDialog: {
-    title: "Carrello di {0}",
+    title: "Carrello di {firstname} {lastname} ({email})",
     emptyCart: "Svuota carrello",
     autoEmptyDisclaimer:
       "Ricorda: non puoi tenere i libri disponibili bloccati nel carrello per troppo tempo, perciò si svuoterà automaticamente tra: {0}",
@@ -231,7 +231,7 @@ export default {
     },
   },
   receiptsDialog: {
-    title: "Ricevute",
+    title: "Ricevute di {firstname} {lastname} ({email})",
     createdBy: "Creata da",
     resend: "Invia di nuovo",
     resendSuccess:

--- a/packages/client/src/pages/manage-users.vue
+++ b/packages/client/src/pages/manage-users.vue
@@ -82,9 +82,9 @@
                   : `user-row-${props.row.id}`
               "
               :tabindex="props.rowIndex"
-              @focusin="toggleSelectedClass(props.row.id, true)"
-              @blur="toggleSelectedClass(props.row.id)"
-              @keydown.escape="toggleSelectedClass(props.row.id)"
+              @focusin="updateSelectedStatus(props.row.id, 'selected')"
+              @blur="updateSelectedStatus(props.row.id, 'deselected')"
+              @keydown.escape="updateSelectedStatus(props.row.id, 'deselected')"
             >
               <q-td key="edit" :props>
                 <q-btn
@@ -502,16 +502,26 @@ onMounted(() => {
   tableRef.value.requestServerInteraction();
 });
 
-// Since for the table we are using the body slot, referencing a variable
-// from the template would cause a re-render of all rows, which heavily
-// impacted performance
-function toggleSelectedClass(rowId: string, forceState?: boolean) {
+// Since we are using the table body slot, using a reactive ref to the table (e.g. tableRef)
+// would cause a massive re-render of all rows for every access, causing a huge performance issue
+// That's why we directly manipulate the DOM to toggle the selected class on focus/blur/escape
+function updateSelectedStatus(
+  rowId: string,
+  newStatus: "selected" | "deselected",
+) {
   const tableRow = document.getElementsByClassName(`user-row-${rowId}`)[0];
   if (!tableRow) {
     return;
   }
 
-  tableRow.classList.toggle("bg-primary-selected", forceState);
+  switch (newStatus) {
+    case "selected":
+      tableRow.classList.add("bg-primary-selected");
+      break;
+    case "deselected":
+      tableRow.classList.remove("bg-primary-selected");
+      break;
+  }
 }
 
 const onRequest: QTableProps["onRequest"] = async (requested) => {

--- a/packages/client/src/pages/manage-users.vue
+++ b/packages/client/src/pages/manage-users.vue
@@ -77,8 +77,14 @@
             <q-tr
               :props
               :class="
-                !props.row.emailVerified ? 'bg-blue-grey-1 text-black-54' : ''
+                !props.row.emailVerified
+                  ? 'bg-blue-grey-1 text-black-54'
+                  : `user-row-${props.row.id}`
               "
+              :tabindex="props.rowIndex"
+              @focusin="toggleSelectedClass(props.row.id, true)"
+              @blur="toggleSelectedClass(props.row.id)"
+              @keydown.escape="toggleSelectedClass(props.row.id)"
             >
               <q-td key="edit" :props>
                 <q-btn
@@ -495,6 +501,18 @@ const { filterMethod, filterOptions, tableFilter, refetchFilterProxy } =
 onMounted(() => {
   tableRef.value.requestServerInteraction();
 });
+
+// Since for the table we are using the body slot, referencing a variable
+// from the template would cause a re-render of all rows, which heavily
+// impacted performance
+function toggleSelectedClass(rowId: string, forceState?: boolean) {
+  const tableRow = document.getElementsByClassName(`user-row-${rowId}`)[0];
+  if (!tableRow) {
+    return;
+  }
+
+  tableRow.classList.toggle("bg-primary-selected", forceState);
+}
 
 const onRequest: QTableProps["onRequest"] = async (requested) => {
   await fetchCustomers({


### PR DESCRIPTION
Fixes #125

This feature adds row selection
To select a row, simply click it or tab into it
To deselect, select another row or press esc

The email of the current customer has also been added to the headers of all user management dialogs

### Additional info
The "selected" class was added through DOM querying and per-row classes to avoid the re-render of the whole body slot, which would be triggered if referencing any reactive script dependency on the root QTr element of the slot