### PR TITLE
feat(client): 219 add page number input to dialog-table pagination

### DIFF
--- a/packages/client/src/components/manage-users/dialog-table.vue
+++ b/packages/client/src/components/manage-users/dialog-table.vue
@@ -51,13 +51,12 @@
           v-if="slotData.pagesNumber > 2"
           :model-value="slotData.pagination.page"
           :disable="loading"
-          :rules="[
-            allowOnlyIntegerNumbers,
-            numberBetween(1, slotData.pagesNumber),
-          ]"
+          :rules="[allowOnlyIntegerNumbers]"
           dense
           outlined
-          @update:model-value="updatePagination"
+          @update:model-value="
+            updatePagination(clamp($event, 1, slotData.pagesNumber))
+          "
         />
 
         <q-btn
@@ -92,12 +91,12 @@ import {
   mdiChevronLeft,
   mdiChevronRight,
 } from "@quasar/extras/mdi-v7";
-import { omit } from "lodash-es";
+import { clamp, omit } from "lodash-es";
 import { QTable, QTableColumn, QTableProps, QTableSlots } from "quasar";
 import { computed, onMounted, ref, type Slot } from "vue";
 import { useI18n } from "vue-i18n";
 import NumberInput from "src/components/manage-users/number-input.vue";
-import { allowOnlyIntegerNumbers, numberBetween } from "src/helpers/rules";
+import { allowOnlyIntegerNumbers } from "src/helpers/rules";
 
 withDefaults(
   defineProps<

--- a/packages/client/src/components/manage-users/dialog-table.vue
+++ b/packages/client/src/components/manage-users/dialog-table.vue
@@ -1,49 +1,111 @@
 <template>
   <q-table
     ref="tableRef"
+    v-model:pagination="pagination"
+    :loading
     :rows="rows"
     :columns="columns"
     :hide-pagination="hidePagination"
-    :pagination="pagination"
     :row-key="rowKey as string"
     :rows-per-page-options="rowsPerPageOptions"
     class="full-height"
     flat
     square
-    @request="props.onRequest"
-    @update:pagination="props['onUpdate:pagination']"
+    @request="onRequest"
   >
-    <template v-for="(_, slotName) in slots" #[slotName]="slotData">
-      <slot :name="slotName" v-bind="slotData" />
+    <template v-for="(_, slotName) in filteredSlots" #[slotName]="slotData">
+      <slot :name="slotName" v-bind="slotData"> </slot>
+    </template>
+
+    <template
+      v-if="pagination?.page !== undefined"
+      #pagination="slotData: PaginationScope"
+    >
+      <slot name="pagination" v-bind="slotData">
+        <span class="q-pr-md">
+          {{ currentPageLabel }}
+        </span>
+
+        <q-btn
+          v-if="slotData.pagesNumber > 2"
+          :disable="slotData.isFirstPage"
+          :icon="mdiChevronDoubleLeft"
+          color="grey-8"
+          round
+          dense
+          flat
+          @click="slotData.firstPage"
+        />
+
+        <q-btn
+          :disable="slotData.isFirstPage"
+          :icon="mdiChevronLeft"
+          color="grey-8"
+          round
+          dense
+          flat
+          @click="slotData.prevPage"
+        />
+
+        <number-input
+          v-if="slotData.pagesNumber > 2"
+          :model-value="slotData.pagination.page"
+          :disable="loading"
+          :rules="[
+            allowOnlyIntegerNumbers,
+            numberBetween(1, slotData.pagesNumber),
+          ]"
+          dense
+          outlined
+          @update:model-value="updatePagination"
+        />
+
+        <q-btn
+          :disable="slotData.isLastPage"
+          :icon="mdiChevronRight"
+          color="grey-8"
+          round
+          dense
+          flat
+          @click="slotData.nextPage"
+        />
+
+        <q-btn
+          v-if="slotData.pagesNumber > 2"
+          :disable="slotData.isLastPage"
+          :icon="mdiChevronDoubleRight"
+          color="grey-8"
+          round
+          dense
+          flat
+          @click="slotData.lastPage"
+        />
+      </slot>
     </template>
   </q-table>
 </template>
 
 <script setup lang="ts" generic="T extends Record<string, any>">
+import {
+  mdiChevronDoubleLeft,
+  mdiChevronDoubleRight,
+  mdiChevronLeft,
+  mdiChevronRight,
+} from "@quasar/extras/mdi-v7";
+import { omit } from "lodash-es";
 import { QTable, QTableColumn, QTableProps, QTableSlots } from "quasar";
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, ref, type Slot } from "vue";
+import { useI18n } from "vue-i18n";
+import NumberInput from "src/components/manage-users/number-input.vue";
+import { allowOnlyIntegerNumbers, numberBetween } from "src/helpers/rules";
 
-const tableRef = ref<QTable>();
-
-const slots = defineSlots<QTableSlots>();
-
-const hidePagination = computed(() =>
-  props.pagination
-    ? (props.pagination.rowsNumber ?? 0) <= (props.pagination.rowsPerPage ?? 1)
-    : true,
-);
-
-const props = withDefaults(
+withDefaults(
   defineProps<
     {
       rows: readonly T[];
       columns?: QTableColumn<T>[];
       rowKey?: Extract<keyof T, string>;
-      // eslint-disable-next-line vue/prop-name-casing
-    } & Pick<
-      QTableProps,
-      "pagination" | "rowsPerPageOptions" | "onRequest" | "onUpdate:pagination"
-    >
+    } & Pick<QTableProps, "loading" | "rowsPerPageOptions" | "onRequest">
   >(),
   {
     columns: undefined,
@@ -52,9 +114,61 @@ const props = withDefaults(
   },
 );
 
+type PaginationScope =
+  QTableSlots["pagination"] extends Slot<infer Scope> ? Scope : never;
+
+const pagination =
+  defineModel<NonNullable<QTableProps["pagination"]>>("pagination");
+
 onMounted(() => {
   tableRef.value?.requestServerInteraction();
 });
+
+const slots = defineSlots<QTableSlots>();
+
+const filteredSlots = omit(slots, "pagination");
+
+const { t } = useI18n();
+
+const currentPageLabel = computed(() => {
+  if (
+    pagination.value?.page === undefined ||
+    pagination.value.rowsNumber === undefined ||
+    pagination.value.rowsPerPage === undefined
+  ) {
+    return;
+  }
+
+  const { rowsNumber, rowsPerPage, page } = pagination.value;
+
+  const currentPageStart = (page - 1) * rowsPerPage;
+
+  return `${currentPageStart + 1}-${Math.min(
+    currentPageStart + rowsPerPage,
+    rowsNumber,
+  )} ${t("common.of").toLowerCase()} ${rowsNumber}`;
+});
+
+const hidePagination = computed(() =>
+  pagination.value
+    ? (pagination.value.rowsNumber ?? 0) <= (pagination.value.rowsPerPage ?? 1)
+    : true,
+);
+
+const tableRef = ref<QTable>();
+
+function updatePagination(newPage: number) {
+  if (!pagination.value || !tableRef.value) {
+    return;
+  }
+
+  pagination.value.page = newPage;
+
+  if (pagination.value.rowsNumber === undefined) {
+    return;
+  }
+  tableRef.value.requestServerInteraction();
+}
 </script>
 
 <style lang="scss">

--- a/packages/client/src/components/manage-users/number-input.vue
+++ b/packages/client/src/components/manage-users/number-input.vue
@@ -1,0 +1,71 @@
+<template>
+  <q-input
+    ref="inputRef"
+    v-bind="props"
+    :model-value
+    :onbeforeinput="validate"
+    :size="modelValue.toString().length"
+    input-class="text-center"
+    inputmode="numeric"
+    hide-bottom-space
+    @focus="inputRef?.select()"
+    @keydown.enter="
+      ({ target }: InputEvent) =>
+        (modelValue = Number((target as HTMLInputElement).value))
+    "
+  />
+</template>
+
+<script setup lang="ts">
+import {
+  QInput,
+  QInputProps,
+  type EmbeddedValidationRule,
+  type EmbeddedValidationRuleFn,
+} from "quasar";
+import { ref } from "vue";
+
+const modelValue = defineModel<number>({ required: true });
+
+const props =
+  defineProps<Omit<QInputProps, "modelValue" | "onUpdate:modelValue">>();
+
+const inputRef = ref<QInput>();
+
+const validate: HTMLInputElement["onbeforeinput"] = (event) => {
+  if (!inputRef.value || !event.target) {
+    return;
+  }
+
+  const target = event.target as HTMLInputElement;
+  const start = target.selectionStart ?? 0;
+  const end = target.selectionEnd ?? target.value.length;
+
+  if (event.data === null) {
+    if (target.value.length - (end - start) > 1) {
+      return;
+    }
+
+    event.preventDefault();
+    return;
+  }
+
+  const newValue =
+    target.value.substring(0, start) + event.data + target.value.substring(end);
+
+  const isInvalid = props.rules?.some(
+    (rule) =>
+      typeof rule === "function" &&
+      rule(
+        newValue,
+        {} as Record<EmbeddedValidationRule, EmbeddedValidationRuleFn>,
+      ) !== true,
+  );
+
+  if (isInvalid || event.data !== parseInt(event.data).toString()) {
+    event.preventDefault();
+
+    return;
+  }
+};
+</script>

--- a/packages/client/src/components/manage-users/number-input.vue
+++ b/packages/client/src/components/manage-users/number-input.vue
@@ -1,4 +1,8 @@
 <template>
+  <!--
+    Displaying errors would break the UI, so we prevent
+    invalid input instead and we don't show any error message
+  -->
   <q-input
     ref="inputRef"
     v-bind="props"
@@ -32,6 +36,9 @@ const props =
 
 const inputRef = ref<QInput>();
 
+// To prevent invalid values while typing, deleting, or pasting,
+// we compute the new value before it is applied to the input's value
+// This requires managing partial or total text selection and replacement
 const validate: HTMLInputElement["onbeforeinput"] = (event) => {
   if (!inputRef.value || !event.target) {
     return;
@@ -41,6 +48,8 @@ const validate: HTMLInputElement["onbeforeinput"] = (event) => {
   const start = target.selectionStart ?? 0;
   const end = target.selectionEnd ?? target.value.length;
 
+  // In case the user is deleting, check if at least one digit remains
+  // If not, prevent the deletion altogether to avoid empty values
   if (event.data === null) {
     if (target.value.length - (end - start) > 1) {
       return;
@@ -53,7 +62,7 @@ const validate: HTMLInputElement["onbeforeinput"] = (event) => {
   const newValue =
     target.value.substring(0, start) + event.data + target.value.substring(end);
 
-  const isInvalid = props.rules?.some(
+  const doesNotSatisfyRules = props.rules?.some(
     (rule) =>
       typeof rule === "function" &&
       rule(
@@ -62,7 +71,10 @@ const validate: HTMLInputElement["onbeforeinput"] = (event) => {
       ) !== true,
   );
 
-  if (isInvalid || event.data !== parseInt(event.data).toString()) {
+  // If the new value does not respect rules validation or if the input
+  // is not a plain text positive integer, prevent the change
+  const isInvalidNumber = isNaN(Number(newValue)) || !/^\d+$/.test(newValue);
+  if (doesNotSatisfyRules || isInvalidNumber) {
     event.preventDefault();
 
     return;

--- a/packages/client/src/i18n/en-US/index.ts
+++ b/packages/client/src/i18n/en-US/index.ts
@@ -68,6 +68,8 @@ export default {
     back: "Back",
     next: "Next",
 
+    of: "Of",
+
     from: "From",
     to: "To",
 

--- a/packages/client/src/i18n/it/index.ts
+++ b/packages/client/src/i18n/it/index.ts
@@ -64,6 +64,8 @@ export default {
     back: "Indietro",
     next: "Avanti",
 
+    of: "Di",
+
     from: "Da",
     to: "A",
 

--- a/packages/client/src/pages/warehouse.vue
+++ b/packages/client/src/pages/warehouse.vue
@@ -40,6 +40,7 @@
         :filter="tableFilter"
         :loading="isLoading"
         :rows="bookRows"
+        :rows-per-page-options="ROWS_PER_PAGE_OPTIONS"
         class="flex-delegate-height-management"
         row-key="id"
         @request="fetchBooksPage"
@@ -125,6 +126,7 @@
         :filter="tableFilter"
         :loading="isLoading"
         :rows="bookCopiesRows"
+        :rows-per-page-options="ROWS_PER_PAGE_OPTIONS"
         class="col"
         @request="fetchBooksPage"
       >
@@ -245,6 +247,8 @@ import {
   BookSummaryFragment,
   PaginatedBookResultFragment,
 } from "src/services/book.graphql";
+
+const ROWS_PER_PAGE_OPTIONS = [30, 50, 100];
 
 const { t } = useI18n();
 


### PR DESCRIPTION
Fixes #219

This feature adds an input field to the warehouse table's pagination to allow users to select the page number

- only valid page numbers are allowed for insertion
- when first focusing the field, the content is automatically selected to allow users

To test it
- Make sure the DB has many book copies by seeding with `pnpm seed-users-with-books -u 10`
- Log in as admin
- Go to the warehouse page
- Trigger a search that will return many book copies (for example "/00")
- Change the page with the field between the arrow buttons
- Try to type/paste/set invalid values