### PR TITLE
fix(client): small fixes

### DIFF
--- a/packages/client/src/components/manage-users/edit-user-reserved-dialog.vue
+++ b/packages/client/src/components/manage-users/edit-user-reserved-dialog.vue
@@ -164,11 +164,7 @@
         </requested-reserved-table>
 
         <span class="q-px-md q-py-md text-h6 text-primary">
-          {{
-            $t("manageUsers.requestedBooksDialog.title", [
-              `${userData.firstname} ${userData.lastname}`,
-            ])
-          }}
+          {{ $t("manageUsers.requestedBooksDialog.title", userData) }}
         </span>
 
         <requested-reserved-table

--- a/packages/client/src/pages/manage-users.vue
+++ b/packages/client/src/pages/manage-users.vue
@@ -83,7 +83,7 @@
               "
               :tabindex="props.rowIndex"
               @focusin="updateSelectedStatus(props.row.id, 'selected')"
-              @blur="updateSelectedStatus(props.row.id, 'deselected')"
+              @focusout="updateSelectedStatus(props.row.id, 'deselected')"
               @keydown.escape="updateSelectedStatus(props.row.id, 'deselected')"
             >
               <q-td key="edit" :props>


### PR DESCRIPTION
This branch implements the following fixes:
- clicking on a row on the manage-users table to open a dialog causes the focus to be lost without a blur event, making the row stay visually selected
- the secondary title bar of the "edit users reserved books" dialog doens't display the user's name