### PR TITLE
feat(server+client): add books and schools import gui

### DIFF
--- a/packages/client/src/components/import-books-and-schools-dialog.vue
+++ b/packages/client/src/components/import-books-and-schools-dialog.vue
@@ -1,0 +1,137 @@
+<template>
+  <q-dialog ref="dialogRef" @hide="onDialogHide">
+    <k-dialog-card
+      :title="t('general.settings.importBooksAndSchools.title')"
+      class="width-700"
+      no-actions
+      size="fullscreen"
+    >
+      <q-card-section
+        class="column gap-8 no-wrap q-pa-lg scroll-y text-black-54 text-size-16"
+      >
+        <span>
+          {{
+            t("general.settings.importBooksAndSchools.pasteUrlBooksDescription")
+          }}
+
+          <a
+            :href="BOOK_LIST_LINK"
+            class="text-primary wrap-break-word"
+            target="_blank"
+          >
+            {{ BOOK_LIST_LINK }}
+          </a>
+        </span>
+
+        <q-input
+          v-model="bookListUrlModel"
+          :label="t('general.settings.importBooksAndSchools.booksUrlLabel')"
+          :rules="[requiredRule, urlRule]"
+          clearable
+          outlined
+        />
+
+        <q-btn
+          :icon="mdiDownload"
+          :label="t('general.settings.importBooksAndSchools.importBooksButton')"
+          color="accent"
+        />
+
+        <span class="q-mt-md">
+          {{
+            t(
+              "general.settings.importBooksAndSchools.pasteUrlSchoolsDescription",
+            )
+          }}
+
+          <a
+            :href="SCHOOL_LIST_LINK"
+            class="text-primary wrap-break-word"
+            target="_blank"
+          >
+            {{ SCHOOL_LIST_LINK }}
+          </a>
+        </span>
+
+        <span class="text-negative">
+          {{ t("general.settings.importBooksAndSchools.schoolsImportWarning") }}
+        </span>
+
+        <q-input
+          v-model="publicSchoolListUrlModel"
+          :label="t('general.settings.importBooksAndSchools.schoolsUrlLabel')"
+          :rules="[requiredRule, urlRule]"
+          clearable
+          outlined
+        />
+
+        <q-input
+          v-model="privateSchoolListUrlModel"
+          :label="
+            t('general.settings.importBooksAndSchools.schoolsPrivateUrlLabel')
+          "
+          :rules="[requiredRule, urlRule]"
+          clearable
+          outlined
+        />
+
+        <q-btn
+          :icon="mdiDownload"
+          :label="
+            t('general.settings.importBooksAndSchools.importSchoolsButton')
+          "
+          color="accent"
+        />
+      </q-card-section>
+
+      <q-separator />
+
+      <q-card-actions align="right">
+        <q-btn :label="t('actions.close')" flat @click="onDialogCancel" />
+      </q-card-actions>
+    </k-dialog-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { mdiDownload } from "@quasar/extras/mdi-v7";
+import { useDialogPluginComponent, type ValidationRule } from "quasar";
+import { ref } from "vue";
+import { useI18n } from "vue-i18n";
+import KDialogCard from "src/components/k-dialog-card.vue";
+import { requiredRule } from "src/helpers/rules";
+
+defineEmits(useDialogPluginComponent.emitsObject);
+
+const { dialogRef, onDialogHide, onDialogCancel } = useDialogPluginComponent();
+
+const { t } = useI18n();
+
+const BOOK_LIST_LINK =
+  "https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Adozioni%20libri%20di%20testo";
+const SCHOOL_LIST_LINK =
+  "https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Adozioni%20libri%20di%20testo";
+
+const bookListUrlModel = ref<string>();
+const publicSchoolListUrlModel = ref<string>();
+const privateSchoolListUrlModel = ref<string>();
+
+const urlRule: ValidationRule<string | null | undefined> = (value) => {
+  if (!value) {
+    return t("validators.nonValidAddress");
+  }
+
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return t("validators.nonValidAddress");
+  }
+};
+</script>
+
+<style scoped lang="scss">
+.wrap-break-word {
+  word-wrap: break-word;
+}
+</style>

--- a/packages/client/src/components/import-books-and-schools-dialog.vue
+++ b/packages/client/src/components/import-books-and-schools-dialog.vue
@@ -7,81 +7,105 @@
       size="fullscreen"
     >
       <q-card-section
-        class="column gap-8 no-wrap q-pa-lg scroll-y text-black-54 text-size-16"
+        class="column gap-24 no-wrap q-pa-lg scroll-y text-black-54 text-size-16"
       >
-        <span>
-          {{
-            t("general.settings.importBooksAndSchools.pasteUrlBooksDescription")
-          }}
+        <q-form class="column gap-8" @submit="handleImportBooks">
+          <span>
+            {{
+              t(
+                "general.settings.importBooksAndSchools.pasteUrlBooksDescription",
+              )
+            }}
 
-          <a
-            :href="BOOK_LIST_LINK"
-            class="text-primary wrap-break-word"
-            target="_blank"
-          >
-            {{ BOOK_LIST_LINK }}
-          </a>
-        </span>
+            <a
+              :href="BOOK_LIST_LINK"
+              class="text-primary wrap-break-word"
+              target="_blank"
+            >
+              {{ BOOK_LIST_LINK }}
+            </a>
+          </span>
 
-        <q-input
-          v-model="bookListUrlModel"
-          :label="t('general.settings.importBooksAndSchools.booksUrlLabel')"
-          :rules="[requiredRule, urlRule]"
-          clearable
-          outlined
-        />
+          <q-input
+            v-model.trim="bookListUrlModel"
+            :label="t('general.settings.importBooksAndSchools.booksUrlLabel')"
+            :rules="[requiredRule, makeValidateUrlRule(BOOKS_URL_PATTERN)]"
+            clearable
+            lazy-rules
+            outlined
+          />
 
-        <q-btn
-          :icon="mdiDownload"
-          :label="t('general.settings.importBooksAndSchools.importBooksButton')"
-          color="accent"
-        />
+          <q-btn
+            :icon="mdiDownload"
+            :label="
+              t('general.settings.importBooksAndSchools.importBooksButton')
+            "
+            :disabled="!isBookUrlFilled"
+            :loading="importBooksLoading"
+            color="accent"
+            type="submit"
+          />
+        </q-form>
 
-        <span class="q-mt-md">
-          {{
-            t(
-              "general.settings.importBooksAndSchools.pasteUrlSchoolsDescription",
-            )
-          }}
+        <q-form class="column gap-8" @submit="handleImportSchools">
+          <span>
+            {{
+              t(
+                "general.settings.importBooksAndSchools.pasteUrlSchoolsDescription",
+              )
+            }}
 
-          <a
-            :href="SCHOOL_LIST_LINK"
-            class="text-primary wrap-break-word"
-            target="_blank"
-          >
-            {{ SCHOOL_LIST_LINK }}
-          </a>
-        </span>
+            <a
+              :href="SCHOOL_LIST_LINK"
+              class="text-primary wrap-break-word"
+              target="_blank"
+            >
+              {{ SCHOOL_LIST_LINK }}
+            </a>
+          </span>
+          <span class="text-negative">
+            {{
+              t("general.settings.importBooksAndSchools.schoolsImportWarning")
+            }}
+          </span>
 
-        <span class="text-negative">
-          {{ t("general.settings.importBooksAndSchools.schoolsImportWarning") }}
-        </span>
+          <q-input
+            v-model.trim="publicSchoolListUrlModel"
+            :label="t('general.settings.importBooksAndSchools.schoolsUrlLabel')"
+            :rules="[
+              requiredRule,
+              makeValidateUrlRule(PUBLIC_SCHOOLS_URL_PATTERN),
+            ]"
+            clearable
+            outlined
+            lazy-rules
+          />
 
-        <q-input
-          v-model="publicSchoolListUrlModel"
-          :label="t('general.settings.importBooksAndSchools.schoolsUrlLabel')"
-          :rules="[requiredRule, urlRule]"
-          clearable
-          outlined
-        />
+          <q-input
+            v-model.trim="privateSchoolListUrlModel"
+            :label="
+              t('general.settings.importBooksAndSchools.schoolsPrivateUrlLabel')
+            "
+            :rules="[
+              requiredRule,
+              makeValidateUrlRule(PRIVATE_SCHOOLS_URL_PATTERN),
+            ]"
+            clearable
+            outlined
+            lazy-rules
+          />
 
-        <q-input
-          v-model="privateSchoolListUrlModel"
-          :label="
-            t('general.settings.importBooksAndSchools.schoolsPrivateUrlLabel')
-          "
-          :rules="[requiredRule, urlRule]"
-          clearable
-          outlined
-        />
-
-        <q-btn
-          :icon="mdiDownload"
-          :label="
-            t('general.settings.importBooksAndSchools.importSchoolsButton')
-          "
-          color="accent"
-        />
+          <q-btn
+            :icon="mdiDownload"
+            :label="
+              t('general.settings.importBooksAndSchools.importSchoolsButton')
+            "
+            :disabled="!areSchoolUrlsFilled || !areBooksImported"
+            :loading="importSchoolsLoading"
+            color="accent"
+            type="submit"
+          />
+        </q-form>
       </q-card-section>
 
       <q-separator />
@@ -95,39 +119,136 @@
 
 <script setup lang="ts">
 import { mdiDownload } from "@quasar/extras/mdi-v7";
-import { useDialogPluginComponent, type ValidationRule } from "quasar";
-import { ref } from "vue";
+import { useDialogPluginComponent, Dialog } from "quasar";
+import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import KDialogCard from "src/components/k-dialog-card.vue";
 import { requiredRule } from "src/helpers/rules";
+import {
+  useImportBooksMutation,
+  useImportSchoolsMutation,
+} from "src/services/book.graphql";
 
 defineEmits(useDialogPluginComponent.emitsObject);
 
 const { dialogRef, onDialogHide, onDialogCancel } = useDialogPluginComponent();
-
 const { t } = useI18n();
 
 const BOOK_LIST_LINK =
   "https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Adozioni%20libri%20di%20testo";
 const SCHOOL_LIST_LINK =
-  "https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Adozioni%20libri%20di%20testo";
+  "https://dati.istruzione.it/opendata/opendata/catalogo/elements1/?area=Scuole";
 
 const bookListUrlModel = ref<string>();
 const publicSchoolListUrlModel = ref<string>();
 const privateSchoolListUrlModel = ref<string>();
 
-const urlRule: ValidationRule<string | null | undefined> = (value) => {
-  if (!value) {
-    return t("validators.nonValidAddress");
+const isBookUrlFilled = computed(() => !!bookListUrlModel.value);
+const areSchoolUrlsFilled = computed(
+  () => !!publicSchoolListUrlModel.value && !!privateSchoolListUrlModel.value,
+);
+
+const { importBooks, loading: importBooksLoading } = useImportBooksMutation();
+const { importSchools, loading: importSchoolsLoading } =
+  useImportSchoolsMutation();
+
+const BOOKS_URL_PATTERN =
+  /^https:\/\/dati\.istruzione\.it\/opendata\/opendata\/catalogo\/elements1\/ALTEMILIAROMAGNA\w*\.csv$/;
+const PUBLIC_SCHOOLS_URL_PATTERN =
+  /^https:\/\/dati\.istruzione\.it\/opendata\/opendata\/catalogo\/elements1\/SCUANAGRAFESTAT\w*\.csv$/;
+const PRIVATE_SCHOOLS_URL_PATTERN =
+  /^https:\/\/dati\.istruzione\.it\/opendata\/opendata\/catalogo\/elements1\/SCUANAGRAFEPAR\w*\.csv$/;
+
+function makeValidateUrlRule(pattern: RegExp) {
+  return (value: string | null | undefined) => {
+    if (!value) {
+      return true;
+    }
+
+    try {
+      new URL(value);
+    } catch {
+      return t("validators.nonValidAddress");
+    }
+
+    if (!pattern.test(value)) {
+      return t("validators.nonValidUrlFormat");
+    }
+
+    return true;
+  };
+}
+
+const areBooksImported = ref(false);
+async function handleImportBooks() {
+  if (!bookListUrlModel.value) {
+    return;
   }
 
   try {
-    new URL(value);
-    return true;
+    const { data } = await importBooks({
+      input: {
+        booksUrl: bookListUrlModel.value,
+      },
+    });
+
+    areBooksImported.value = true;
+    Dialog.create({
+      title: t("general.settings.importBooksAndSchools.importSuccess"),
+      message: t(
+        "general.settings.importBooksAndSchools.importBooksSuccessMessage",
+        {
+          currentDbBooksCount: data.currentDbBooksCount,
+        },
+      ),
+    });
   } catch {
-    return t("validators.nonValidAddress");
+    Dialog.create({
+      title: t("general.settings.importBooksAndSchools.importError"),
+      message: t(
+        "general.settings.importBooksAndSchools.importBooksErrorMessage",
+      ),
+    });
   }
-};
+}
+
+async function handleImportSchools() {
+  if (
+    !publicSchoolListUrlModel.value ||
+    !privateSchoolListUrlModel.value ||
+    !areBooksImported.value
+  ) {
+    return;
+  }
+
+  try {
+    const { data } = await importSchools({
+      input: {
+        publicSchoolsUrl: publicSchoolListUrlModel.value,
+        privateSchoolsUrl: privateSchoolListUrlModel.value,
+      },
+    });
+
+    Dialog.create({
+      title: t("general.settings.importBooksAndSchools.importSuccess"),
+      message: t(
+        "general.settings.importBooksAndSchools.importSchoolsSuccessMessage",
+        {
+          schoolCount: data.schoolCount,
+          coursesCount: data.coursesCount,
+          booksOnCoursesCount: data.booksOnCoursesCount,
+        },
+      ),
+    });
+  } catch {
+    Dialog.create({
+      title: t("general.settings.importBooksAndSchools.importError"),
+      message: t(
+        "general.settings.importBooksAndSchools.importSchoolsErrorMessage",
+      ),
+    });
+  }
+}
 </script>
 
 <style scoped lang="scss">

--- a/packages/client/src/components/import-books-and-schools-dialog.vue
+++ b/packages/client/src/components/import-books-and-schools-dialog.vue
@@ -28,6 +28,7 @@
 
           <q-input
             v-model.trim="bookListUrlModel"
+            :disable="importBooksLoading"
             :label="t('general.settings.importBooksAndSchools.booksUrlLabel')"
             :rules="[requiredRule, makeValidateUrlRule(BOOKS_URL_PATTERN)]"
             clearable
@@ -71,6 +72,7 @@
 
           <q-input
             v-model.trim="publicSchoolListUrlModel"
+            :disable="importSchoolsLoading"
             :label="t('general.settings.importBooksAndSchools.schoolsUrlLabel')"
             :rules="[
               requiredRule,
@@ -83,6 +85,7 @@
 
           <q-input
             v-model.trim="privateSchoolListUrlModel"
+            :disable="importSchoolsLoading"
             :label="
               t('general.settings.importBooksAndSchools.schoolsPrivateUrlLabel')
             "

--- a/packages/client/src/components/import-books-and-schools-dialog.vue
+++ b/packages/client/src/components/import-books-and-schools-dialog.vue
@@ -2,14 +2,12 @@
   <q-dialog ref="dialogRef" persistent @hide="onDialogHide">
     <k-dialog-card
       :title="t('general.settings.importBooksAndSchools.title')"
-      class="width-700"
       no-actions
-      size="fullscreen"
     >
       <q-card-section
-        class="column gap-24 no-wrap q-pa-lg scroll-y text-black-54 text-size-16"
+        class="column full-width gap-24 max-width-700 no-wrap q-pa-lg scroll-y text-black-54 text-size-16"
       >
-        <q-form class="column gap-8" @submit="handleImportBooks">
+        <q-form class="column gap-8 no-wrap" @submit="handleImportBooks">
           <span>
             {{
               t(
@@ -48,7 +46,7 @@
           />
         </q-form>
 
-        <q-form class="column gap-8" @submit="handleImportSchools">
+        <q-form class="column gap-8 no-wrap" @submit="handleImportSchools">
           <span>
             {{
               t(
@@ -72,7 +70,7 @@
 
           <q-input
             v-model.trim="publicSchoolListUrlModel"
-            :disable="importSchoolsLoading"
+            :disable="importSchoolsLoading || !areBooksImported"
             :label="t('general.settings.importBooksAndSchools.schoolsUrlLabel')"
             :rules="[
               requiredRule,
@@ -85,7 +83,7 @@
 
           <q-input
             v-model.trim="privateSchoolListUrlModel"
-            :disable="importSchoolsLoading"
+            :disable="importSchoolsLoading || !areBooksImported"
             :label="
               t('general.settings.importBooksAndSchools.schoolsPrivateUrlLabel')
             "
@@ -105,6 +103,7 @@
             "
             :disabled="!areSchoolUrlsFilled || !areBooksImported"
             :loading="importSchoolsLoading"
+            class="full-width"
             color="accent"
             type="submit"
           />
@@ -256,6 +255,7 @@ async function handleImportSchools() {
 
 <style scoped lang="scss">
 .wrap-break-word {
+  text-wrap: wrap;
   word-wrap: break-word;
 }
 </style>

--- a/packages/client/src/components/import-books-and-schools-dialog.vue
+++ b/packages/client/src/components/import-books-and-schools-dialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-dialog ref="dialogRef" @hide="onDialogHide">
+  <q-dialog ref="dialogRef" persistent @hide="onDialogHide">
     <k-dialog-card
       :title="t('general.settings.importBooksAndSchools.title')"
       class="width-700"

--- a/packages/client/src/components/import-books-and-schools-dialog.vue
+++ b/packages/client/src/components/import-books-and-schools-dialog.vue
@@ -2,6 +2,7 @@
   <q-dialog ref="dialogRef" persistent @hide="onDialogHide">
     <k-dialog-card
       :title="t('general.settings.importBooksAndSchools.title')"
+      size="fullscreen"
       no-actions
     >
       <q-card-section
@@ -26,7 +27,7 @@
 
           <q-input
             v-model.trim="bookListUrlModel"
-            :disable="importBooksLoading"
+            :disable="importBooksLoading || importSchoolsLoading"
             :label="t('general.settings.importBooksAndSchools.booksUrlLabel')"
             :rules="[requiredRule, makeValidateUrlRule(BOOKS_URL_PATTERN)]"
             clearable
@@ -39,7 +40,7 @@
             :label="
               t('general.settings.importBooksAndSchools.importBooksButton')
             "
-            :disabled="!isBookUrlFilled"
+            :disabled="!isBookUrlFilled || importSchoolsLoading"
             :loading="importBooksLoading"
             color="accent"
             type="submit"
@@ -124,9 +125,12 @@ import { mdiDownload } from "@quasar/extras/mdi-v7";
 import { useDialogPluginComponent, Dialog } from "quasar";
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
+import { evictQuery } from "src/apollo/cache";
 import KDialogCard from "src/components/k-dialog-card.vue";
 import { requiredRule } from "src/helpers/rules";
+import { useBookService } from "src/services/book";
 import {
+  GetBooksDocument,
   useImportBooksMutation,
   useImportSchoolsMutation,
 } from "src/services/book.graphql";
@@ -181,20 +185,22 @@ function makeValidateUrlRule(pattern: RegExp) {
   };
 }
 
-const areBooksImported = ref(false);
+const { booksPaginationDetails } = useBookService(ref(0), ref(1));
+const areBooksImported = computed(
+  () => booksPaginationDetails.value.rowCount > 0,
+);
 async function handleImportBooks() {
   if (!bookListUrlModel.value) {
     return;
   }
 
   try {
-    const { data } = await importBooks({
+    const { data, cache } = await importBooks({
       input: {
         booksUrl: bookListUrlModel.value,
       },
     });
 
-    areBooksImported.value = true;
     Dialog.create({
       title: t("general.settings.importBooksAndSchools.importSuccess"),
       message: t(
@@ -204,6 +210,9 @@ async function handleImportBooks() {
         },
       ),
     });
+
+    evictQuery(cache, GetBooksDocument);
+    cache.gc();
   } catch {
     Dialog.create({
       title: t("general.settings.importBooksAndSchools.importError"),

--- a/packages/client/src/components/settings-dialog.vue
+++ b/packages/client/src/components/settings-dialog.vue
@@ -1,7 +1,7 @@
 <template>
   <q-dialog ref="dialogRef" persistent @hide="onDialogHide">
     <k-dialog-form-card
-      :title="t('sidebar.settings')"
+      :title="t('general.settings.general')"
       actions-padding
       class="full-width max-width-700"
       size="fullscreen"

--- a/packages/client/src/i18n/en-US/general.ts
+++ b/packages/client/src/i18n/en-US/general.ts
@@ -104,6 +104,16 @@ export default {
       schoolsPrivateUrlLabel:
         "CSV URL for the List of Private Schools of Emilia Romagna",
       importSchoolsButton: "Import school lists",
+      importSuccess: "Import successful",
+      importBooksSuccessMessage:
+        "The import process has been completed. There are now {currentDbBooksCount} books in the database.",
+      importError: "Import failed",
+      importBooksErrorMessage:
+        "Something went wrong, the import operation failed. Check that you entered the correct URL.",
+      importSchoolsSuccessMessage:
+        "{schoolCount} schools were imported, for a total of {coursesCount} courses containing a total of {booksOnCoursesCount} books.",
+      importSchoolsErrorMessage:
+        "Something went wrong, the import operation failed. Check that you entered the correct URLs.",
     },
   },
   role: "Role",

--- a/packages/client/src/i18n/en-US/general.ts
+++ b/packages/client/src/i18n/en-US/general.ts
@@ -88,6 +88,23 @@ export default {
     downloadUserListSuccess: "The user list will be downloaded shortly",
     downloadUserListFailed:
       "Could not download the user list. Please contact the support.",
+    general: "General",
+    importBooksAndSchools: {
+      title: "Import books and schools",
+      pasteUrlBooksDescription:
+        "Paste the URL in the field below and click the button to import the book lists made available by the Ministry. You can retrieve the URL to obtain the book lists from this link:",
+      booksUrlLabel: "CSV URL for the Book List of Emilia Romagna",
+      importBooksButton: "Import book lists",
+      pasteUrlSchoolsDescription:
+        "Paste the URLs in the fields below and click the button to import the school lists made available by the Ministry. You can retrieve the URLs to obtain the school lists from this link:",
+      schoolsImportWarning:
+        "Important: before you can import the school lists, you must have already imported the book list using the field above.",
+      schoolsUrlLabel:
+        "CSV URL for the List of State Schools of Emilia Romagna",
+      schoolsPrivateUrlLabel:
+        "CSV URL for the List of Private Schools of Emilia Romagna",
+      importSchoolsButton: "Import school lists",
+    },
   },
   role: "Role",
   rolesAndPermissions: {

--- a/packages/client/src/i18n/en-US/validators.ts
+++ b/packages/client/src/i18n/en-US/validators.ts
@@ -8,6 +8,7 @@ export default {
   exactLength: "The value must be exactly {exactLength} characters long",
   nonValidEmail: "The email is not valid",
   nonValidDomain: "The domain is not valid",
+  nonValidAddress: "The address is not valid",
   password: {
     atLeastOneNumber: "The password should contain at least one number",
     atLeastOneLowercase:

--- a/packages/client/src/i18n/en-US/validators.ts
+++ b/packages/client/src/i18n/en-US/validators.ts
@@ -9,6 +9,7 @@ export default {
   nonValidEmail: "The email is not valid",
   nonValidDomain: "The domain is not valid",
   nonValidAddress: "The address is not valid",
+  nonValidUrlFormat: "The URL format is not valid",
   password: {
     atLeastOneNumber: "The password should contain at least one number",
     atLeastOneLowercase:

--- a/packages/client/src/i18n/it/general.ts
+++ b/packages/client/src/i18n/it/general.ts
@@ -105,6 +105,16 @@ export default {
       schoolsPrivateUrlLabel:
         "URL CSV Della Lista Delle Scuole Paritarie dell'Emilia Romagna",
       importSchoolsButton: "Importa gli elenchi delle scuole",
+      importSuccess: "Import riuscito",
+      importBooksSuccessMessage:
+        "Il processo di import è stato completato. Ora sono presenti {currentDbBooksCount} libri nel database.",
+      importError: "Import non riuscito",
+      importBooksErrorMessage:
+        "Qualcosa è andato storto, l'operazione di import non è riuscita. Controlla di aver inserito l'URL corretto.",
+      importSchoolsSuccessMessage:
+        "Sono state importate {schoolCount} scuole, per un totale di {coursesCount} corsi comprendenti un totale di {booksOnCoursesCount} libri.",
+      importSchoolsErrorMessage:
+        "Qualcosa è andato storto, l'operazione di import non è riuscita. Controlla di aver inserito gli URL corretti.",
     },
   },
   role: "Ruolo",

--- a/packages/client/src/i18n/it/general.ts
+++ b/packages/client/src/i18n/it/general.ts
@@ -89,6 +89,23 @@ export default {
       "Il download della lista degli utenti inizierà a breve",
     downloadUserListFailed:
       "Non è stato possibile scaricare la lista degli utenti. Contattate il supporto tecnico.",
+    general: "Generali",
+    importBooksAndSchools: {
+      title: "Import libri e scuole",
+      pasteUrlBooksDescription:
+        "Incolla l'URL nel campo qui sotto e clicca il bottone per importare gli elenchi dei libri resi disponibile dal Ministero. Puoi recuperare l'URL per ottenere gli elenchi dei libri da questo link:",
+      booksUrlLabel: "URL CSV Della Lista dei Libri dell'Emilia Romagna",
+      importBooksButton: "Importa gli elenchi dei libri",
+      pasteUrlSchoolsDescription:
+        "Incolla gli URL nei campi qui sotto e clicca il bottone per importare gli elenchi delle scuole resi disponibili dal Ministero. Puoi recuperare gli URL per ottenere gli elenchi delle scuole da questo link:",
+      schoolsImportWarning:
+        "Importante: prima di poter importare gli elenchi delle scuole devi avere già importato l'elenco dei libri usando il campo qui sopra.",
+      schoolsUrlLabel:
+        "URL CSV della Lista Delle Scuole Statali dell'Emilia Romagna",
+      schoolsPrivateUrlLabel:
+        "URL CSV Della Lista Delle Scuole Paritarie dell'Emilia Romagna",
+      importSchoolsButton: "Importa gli elenchi delle scuole",
+    },
   },
   role: "Ruolo",
   rolesAndPermissions: {

--- a/packages/client/src/i18n/it/validators.ts
+++ b/packages/client/src/i18n/it/validators.ts
@@ -10,6 +10,7 @@ export default {
   nonValidEmail: "La mail inserita non è valida",
   nonValidDomain: "Il dominio inserito non è valido",
   nonValidAddress: "L'indirizzo inserito non è valido",
+  nonValidUrlFormat: "Il formato dell'URL non è valido",
   password: {
     atLeastOneNumber: "La password deve contenere almeno un numero",
     atLeastOneLowercase:

--- a/packages/client/src/i18n/it/validators.ts
+++ b/packages/client/src/i18n/it/validators.ts
@@ -9,6 +9,7 @@ export default {
     "Il valore deve essere lungo esattamente {exactLength} caratteri",
   nonValidEmail: "La mail inserita non è valida",
   nonValidDomain: "Il dominio inserito non è valido",
+  nonValidAddress: "L'indirizzo inserito non è valido",
   password: {
     atLeastOneNumber: "La password deve contenere almeno un numero",
     atLeastOneLowercase:

--- a/packages/client/src/layouts/authenticated-layout.vue
+++ b/packages/client/src/layouts/authenticated-layout.vue
@@ -325,24 +325,61 @@
         <template v-if="hasAdminRole">
           <q-separator />
 
-          <q-item
-            v-ripple
-            active-class="bg-black-activated-light"
-            clickable
-            @click="openSettings()"
-          >
-            <q-tooltip v-if="isDrawerMini" v-bind="TOOLTIP_SHARED_PROPS">
-              {{ t(`sidebar.settings`) }}
-            </q-tooltip>
-            <q-item-section side>
-              <q-icon :name="mdiCog" color="black-54" />
-            </q-item-section>
-            <q-item-section>
-              <q-item-label class="ellipsis text-size-16">
+          <q-expansion-item :expand-icon="mdiChevronDown">
+            <template #header>
+              <q-tooltip v-if="isDrawerMini" v-bind="TOOLTIP_SHARED_PROPS">
                 {{ t("sidebar.settings") }}
-              </q-item-label>
-            </q-item-section>
-          </q-item>
+              </q-tooltip>
+              <q-item-section side>
+                <q-icon :name="mdiCog" color="black-54" />
+              </q-item-section>
+              <q-item-section>
+                <q-item-label class="ellipsis text-size-16">
+                  {{ t("sidebar.settings") }}
+                </q-item-label>
+              </q-item-section>
+            </template>
+
+            <q-list>
+              <q-item
+                v-ripple
+                active-class="bg-black-activated-light"
+                clickable
+                @click="openSettings()"
+              >
+                <q-tooltip v-if="isDrawerMini" v-bind="TOOLTIP_SHARED_PROPS">
+                  {{ t("general.settings.general") }}
+                </q-tooltip>
+                <q-item-section side>
+                  <q-icon :name="mdiTune" color="black-54" />
+                </q-item-section>
+                <q-item-section>
+                  <q-item-label class="ellipsis text-size-16">
+                    {{ t("general.settings.general") }}
+                  </q-item-label>
+                </q-item-section>
+              </q-item>
+
+              <q-item
+                v-ripple
+                active-class="bg-black-activated-light"
+                clickable
+                @click="openImportDialog()"
+              >
+                <q-tooltip v-if="isDrawerMini" v-bind="TOOLTIP_SHARED_PROPS">
+                  {{ t("general.settings.importBooksAndSchools.title") }}
+                </q-tooltip>
+                <q-item-section side>
+                  <q-icon :name="mdiDownload" color="black-54" />
+                </q-item-section>
+                <q-item-section>
+                  <q-item-label class="ellipsis text-size-16">
+                    {{ t("general.settings.importBooksAndSchools.title") }}
+                  </q-item-label>
+                </q-item-section>
+              </q-item>
+            </q-list>
+          </q-expansion-item>
 
           <q-separator />
 
@@ -479,10 +516,12 @@ import {
   mdiBookshelf,
   mdiChartLine,
   mdiCheckDecagram,
+  mdiChevronDown,
   mdiCloudCheckOutline,
   mdiCloudOffOutline,
   mdiCog,
   mdiCurrencyEur,
+  mdiDownload,
   mdiExitToApp,
   mdiFrequentlyAskedQuestions,
   mdiHandshake,
@@ -493,6 +532,7 @@ import {
   mdiMenuDown,
   mdiPencilCircle,
   mdiPhone,
+  mdiTune,
   mdiWeb,
 } from "@quasar/extras/mdi-v7";
 import { useOnline } from "@vueuse/core";
@@ -502,6 +542,7 @@ import { useI18n } from "vue-i18n";
 import { setLanguage } from "src/boot/i18n";
 import AppDrawer from "src/components/app-drawer.vue";
 import HeaderBar from "src/components/header-bar.vue";
+import ImportBooksAndSchoolsDialog from "src/components/import-books-and-schools-dialog.vue";
 import {
   type SettingsDialogProps,
   type SettingsUpdate,
@@ -677,6 +718,12 @@ function openSettings() {
         message: t("general.settings.downloadUserListSuccess"),
       });
     }
+  });
+}
+
+function openImportDialog() {
+  Dialog.create({
+    component: ImportBooksAndSchoolsDialog,
   });
 }
 </script>

--- a/packages/client/src/services/book.graphql
+++ b/packages/client/src/services/book.graphql
@@ -91,3 +91,17 @@ mutation createNewBook($input: BookCreateInput!) {
     ...BookSummary
   }
 }
+
+mutation importBooks($input: ImportBooksInput!) {
+  importBooks(input: $input) {
+    currentDbBooksCount
+  }
+}
+
+mutation importSchools($input: ImportSchoolsInput!) {
+  importSchools(input: $input) {
+    schoolCount
+    coursesCount
+    booksOnCoursesCount
+  }
+}

--- a/packages/server/src/modules/book/book-import.constants.ts
+++ b/packages/server/src/modules/book/book-import.constants.ts
@@ -1,0 +1,15 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-imports
+import type { ImportBooksAndSchoolsService } from "src/modules/book/import-books-and-schools.service";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-imports
+import type { ImportBooksCommand } from "src/modules/book/import-books.command";
+
+/**
+ * Filenames for book and school CSV imports from the ministry.
+ * These filenames are expected by both the import service and import command.
+ * IMPORTANT: check both {@link ImportBooksAndSchoolsService} and
+ * {@link ImportBooksCommand} before making changes in this file
+ */
+
+export const BOOK_IMPORT_FILENAME = "ALTEMILIAROMAGNA.csv";
+export const PUBLIC_SCHOOLS_IMPORT_FILENAME = "SCUOLE_STATALI.csv";
+export const PRIVATE_SCHOOLS_IMPORT_FILENAME = "SCUOLE_PARITARIE.csv";

--- a/packages/server/src/modules/book/book.args.ts
+++ b/packages/server/src/modules/book/book.args.ts
@@ -67,3 +67,36 @@ export class BookCreateInput extends IntersectionType(
   LocationBoundInput,
   InputType,
 ) {}
+
+@InputType()
+export class ImportBooksInput {
+  @Field()
+  booksUrl!: string;
+}
+
+@ObjectType()
+export class ImportBooksResult {
+  @Field(() => Int)
+  currentDbBooksCount!: number;
+}
+
+@InputType()
+export class ImportSchoolsInput {
+  @Field()
+  publicSchoolsUrl!: string;
+
+  @Field()
+  privateSchoolsUrl!: string;
+}
+
+@ObjectType()
+export class ImportSchoolsResult {
+  @Field(() => Int)
+  schoolCount!: number;
+
+  @Field(() => Int)
+  coursesCount!: number;
+
+  @Field(() => Int)
+  booksOnCoursesCount!: number;
+}

--- a/packages/server/src/modules/book/book.module.ts
+++ b/packages/server/src/modules/book/book.module.ts
@@ -1,11 +1,13 @@
 import { Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
+import { AuthModule } from "src/modules/auth/auth.module";
+import { ImportBooksAndSchoolsService } from "src/modules/book/import-books-and-schools.service";
 import { ImportBooksCommand } from "src/modules/book/import-books.command";
 import { PrismaModule } from "../prisma/prisma.module";
 import { BookResolver } from "./book.resolver";
 
 @Module({
-  imports: [PrismaModule, ConfigModule],
-  providers: [BookResolver, ImportBooksCommand],
+  imports: [PrismaModule, ConfigModule, AuthModule],
+  providers: [BookResolver, ImportBooksCommand, ImportBooksAndSchoolsService],
 })
 export class BookModule {}

--- a/packages/server/src/modules/book/book.resolver.ts
+++ b/packages/server/src/modules/book/book.resolver.ts
@@ -471,20 +471,20 @@ export class BookResolver {
   @Mutation(() => ImportBooksResult)
   async importBooks(
     @Input() { booksUrl }: ImportBooksInput,
-    @CurrentUser() { id: userId }: User,
+    @CurrentUser("id") currentUserId: string,
   ): Promise<ImportBooksResult> {
-    return this.importService.importBooksFromUrl(booksUrl, userId);
+    return this.importService.importBooksFromUrl(booksUrl, currentUserId);
   }
 
   @Mutation(() => ImportSchoolsResult)
   async importSchools(
     @Input() { publicSchoolsUrl, privateSchoolsUrl }: ImportSchoolsInput,
-    @CurrentUser() { id: userId }: User,
+    @CurrentUser("id") currentUserId: string,
   ): Promise<ImportSchoolsResult> {
     return this.importService.importSchoolsFromUrls(
       publicSchoolsUrl,
       privateSchoolsUrl,
-      userId,
+      currentUserId,
     );
   }
 }

--- a/packages/server/src/modules/book/book.resolver.ts
+++ b/packages/server/src/modules/book/book.resolver.ts
@@ -17,13 +17,25 @@ import { CurrentUser } from "src/modules/auth/decorators/current-user.decorator"
 import { BookUtility } from "src/modules/book/book-utility";
 import { Input } from "../auth/decorators/input.decorator";
 import { PrismaService } from "../prisma/prisma.service";
-import { BookCreateInput, BookQueryArgs, BookQueryResult } from "./book.args";
+import {
+  BookCreateInput,
+  BookQueryArgs,
+  BookQueryResult,
+  ImportBooksInput,
+  ImportBooksResult,
+  ImportSchoolsInput,
+  ImportSchoolsResult,
+} from "./book.args";
+import { ImportBooksAndSchoolsService } from "./import-books-and-schools.service";
 
 const MAX_ROWS_PER_PAGE = 100;
 
 @Resolver(() => Book)
 export class BookResolver {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly importService: ImportBooksAndSchoolsService,
+  ) {}
 
   @Query(() => BookQueryResult)
   async books(
@@ -454,5 +466,25 @@ export class BookResolver {
         title,
       },
     });
+  }
+
+  @Mutation(() => ImportBooksResult)
+  async importBooks(
+    @Input() { booksUrl }: ImportBooksInput,
+    @CurrentUser() { id: userId }: User,
+  ): Promise<ImportBooksResult> {
+    return this.importService.importBooksFromUrl(booksUrl, userId);
+  }
+
+  @Mutation(() => ImportSchoolsResult)
+  async importSchools(
+    @Input() { publicSchoolsUrl, privateSchoolsUrl }: ImportSchoolsInput,
+    @CurrentUser() { id: userId }: User,
+  ): Promise<ImportSchoolsResult> {
+    return this.importService.importSchoolsFromUrls(
+      publicSchoolsUrl,
+      privateSchoolsUrl,
+      userId,
+    );
   }
 }

--- a/packages/server/src/modules/book/import-books-and-schools.service.ts
+++ b/packages/server/src/modules/book/import-books-and-schools.service.ts
@@ -133,10 +133,24 @@ export class ImportBooksAndSchoolsService {
 
       this.logger.log("Starting schools import from URLs");
 
-      await Promise.all([
-        this.downloadFile(publicSchoolsUrl, PUBLIC_SCHOOLS_IMPORT_FILENAME),
-        this.downloadFile(privateSchoolsUrl, PRIVATE_SCHOOLS_IMPORT_FILENAME),
-      ]);
+      const schoolsController = new AbortController();
+      try {
+        await Promise.all([
+          this.downloadFile(
+            publicSchoolsUrl,
+            PUBLIC_SCHOOLS_IMPORT_FILENAME,
+            schoolsController,
+          ),
+          this.downloadFile(
+            privateSchoolsUrl,
+            PRIVATE_SCHOOLS_IMPORT_FILENAME,
+            schoolsController,
+          ),
+        ]);
+      } catch (error) {
+        schoolsController.abort();
+        throw error;
+      }
 
       await this.importBooksCommand.loadSchools();
 
@@ -172,10 +186,14 @@ export class ImportBooksAndSchoolsService {
     return new InternalServerErrorException(context);
   }
 
-  private async downloadFile(sourceUrl: string, destinationFilename: string) {
+  private async downloadFile(
+    sourceUrl: string,
+    destinationFilename: string,
+    sharedController?: AbortController,
+  ) {
     this.logger.log(`Downloading ${destinationFilename} from ${sourceUrl}`);
 
-    const controller = new AbortController();
+    const controller = sharedController ?? new AbortController();
     const timeoutId = setTimeout(() => {
       controller.abort();
     }, this.FETCH_TIMEOUT_MS);

--- a/packages/server/src/modules/book/import-books-and-schools.service.ts
+++ b/packages/server/src/modules/book/import-books-and-schools.service.ts
@@ -19,10 +19,6 @@ import {
 } from "src/modules/book/book-import.constants";
 import { ImportBooksCommand } from "src/modules/book/import-books.command";
 import { PrismaService } from "src/modules/prisma/prisma.service";
-import type {
-  ImportBooksResult,
-  ImportSchoolsResult,
-} from "src/modules/book/book.args";
 
 @Injectable()
 export class ImportBooksAndSchoolsService {
@@ -50,14 +46,9 @@ export class ImportBooksAndSchoolsService {
     this.tmpPath = resolve(rootConfig.storagePath, "./tmp");
   }
 
-  async importBooksFromUrl(
-    booksUrl: string,
-    userId: string,
-    retailLocationId?: string,
-  ): Promise<ImportBooksResult> {
+  async importBooksFromUrl(booksUrl: string, userId: string) {
     await this.authService.assertMembership({
       userId,
-      retailLocationId,
       role: Role.ADMIN,
     });
 
@@ -95,11 +86,9 @@ export class ImportBooksAndSchoolsService {
     publicSchoolsUrl: string,
     privateSchoolsUrl: string,
     userId: string,
-    retailLocationId?: string,
-  ): Promise<ImportSchoolsResult> {
+  ) {
     await this.authService.assertMembership({
       userId,
-      retailLocationId,
       role: Role.ADMIN,
     });
 
@@ -231,7 +220,7 @@ export class ImportBooksAndSchoolsService {
       this.logger.log(`File ${destinationFilename} downloaded successfully`);
     } catch (error) {
       // See https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch#exceptions
-      if (error instanceof DOMException && error.name === "AbortError") {
+      if (error instanceof Error && error.name === "AbortError") {
         throw new BadRequestException(
           `Download timeout: request took longer than ${this.FETCH_TIMEOUT_MS / 1000} seconds`,
         );

--- a/packages/server/src/modules/book/import-books-and-schools.service.ts
+++ b/packages/server/src/modules/book/import-books-and-schools.service.ts
@@ -1,0 +1,243 @@
+import { writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import {
+  Inject,
+  Injectable,
+  Logger,
+  BadRequestException,
+  InternalServerErrorException,
+  ConflictException,
+  HttpException,
+} from "@nestjs/common";
+import { Role } from "@prisma/client";
+import { RootConfiguration, rootConfiguration } from "src/config/root";
+import { AuthService } from "src/modules/auth/auth.service";
+import {
+  BOOK_IMPORT_FILENAME,
+  PUBLIC_SCHOOLS_IMPORT_FILENAME,
+  PRIVATE_SCHOOLS_IMPORT_FILENAME,
+} from "src/modules/book/book-import.constants";
+import { ImportBooksCommand } from "src/modules/book/import-books.command";
+import { PrismaService } from "src/modules/prisma/prisma.service";
+import type {
+  ImportBooksResult,
+  ImportSchoolsResult,
+} from "src/modules/book/book.args";
+
+@Injectable()
+export class ImportBooksAndSchoolsService {
+  private readonly logger = new Logger(ImportBooksAndSchoolsService.name);
+  private readonly tmpPath: string;
+
+  private readonly FETCH_TIMEOUT_MS = 60 * 1000; // 1 minute
+
+  private readonly BOOKS_URL_PATTERN =
+    /^https:\/\/dati\.istruzione\.it\/opendata\/opendata\/catalogo\/elements1\/ALTEMILIAROMAGNA\w*\.csv$/;
+  private readonly PUBLIC_SCHOOLS_URL_PATTERN =
+    /^https:\/\/dati\.istruzione\.it\/opendata\/opendata\/catalogo\/elements1\/SCUANAGRAFESTAT\w*\.csv$/;
+  private readonly PRIVATE_SCHOOLS_URL_PATTERN =
+    /^https:\/\/dati\.istruzione\.it\/opendata\/opendata\/catalogo\/elements1\/SCUANAGRAFEPAR\w*\.csv$/;
+
+  private isImporting = false;
+
+  constructor(
+    @Inject(rootConfiguration.KEY)
+    rootConfig: RootConfiguration,
+    private readonly prisma: PrismaService,
+    private readonly importBooksCommand: ImportBooksCommand,
+    private readonly authService: AuthService,
+  ) {
+    this.tmpPath = resolve(rootConfig.storagePath, "./tmp");
+  }
+
+  async importBooksFromUrl(
+    booksUrl: string,
+    userId: string,
+    retailLocationId?: string,
+  ): Promise<ImportBooksResult> {
+    await this.authService.assertMembership({
+      userId,
+      retailLocationId,
+      role: Role.ADMIN,
+    });
+
+    if (this.isImporting) {
+      throw new ConflictException(
+        "An import operation is already in progress. Please wait for it to complete.",
+      );
+    }
+
+    this.isImporting = true;
+
+    try {
+      this.validateUrlPattern(
+        booksUrl,
+        this.BOOKS_URL_PATTERN,
+        "Invalid books URL",
+      );
+      this.logger.log("Starting books import from URL");
+
+      await this.downloadFile(booksUrl, BOOK_IMPORT_FILENAME);
+      const result = await this.importBooksCommand.loadBooks();
+
+      return {
+        currentDbBooksCount: result,
+      };
+    } catch (error) {
+      this.logger.error("Error importing books:", error);
+      throw this.handleError(error, "Failed to import books");
+    } finally {
+      this.isImporting = false;
+    }
+  }
+
+  async importSchoolsFromUrls(
+    publicSchoolsUrl: string,
+    privateSchoolsUrl: string,
+    userId: string,
+    retailLocationId?: string,
+  ): Promise<ImportSchoolsResult> {
+    await this.authService.assertMembership({
+      userId,
+      retailLocationId,
+      role: Role.ADMIN,
+    });
+
+    if (this.isImporting) {
+      throw new ConflictException(
+        "An import operation is already in progress. Please wait for it to complete.",
+      );
+    }
+
+    this.isImporting = true;
+
+    try {
+      const booksCount = await this.prisma.book.count();
+
+      if (booksCount === 0) {
+        throw new BadRequestException(
+          "No books found in the database. Please import books first.",
+        );
+      }
+
+      this.validateUrlPattern(
+        publicSchoolsUrl,
+        this.PUBLIC_SCHOOLS_URL_PATTERN,
+        "Invalid public schools URL",
+      );
+      this.validateUrlPattern(
+        privateSchoolsUrl,
+        this.PRIVATE_SCHOOLS_URL_PATTERN,
+        "Invalid private schools URL",
+      );
+
+      this.logger.log("Starting schools import from URLs");
+
+      await Promise.all([
+        this.downloadFile(publicSchoolsUrl, PUBLIC_SCHOOLS_IMPORT_FILENAME),
+        this.downloadFile(privateSchoolsUrl, PRIVATE_SCHOOLS_IMPORT_FILENAME),
+      ]);
+
+      await this.importBooksCommand.loadSchools();
+
+      const [schoolCount, coursesCount, booksOnCoursesCount] =
+        await Promise.all([
+          this.prisma.school.count(),
+          this.prisma.schoolCourse.count(),
+          this.prisma.booksOnCourses.count(),
+        ]);
+
+      return {
+        schoolCount,
+        coursesCount,
+        booksOnCoursesCount,
+      };
+    } catch (error) {
+      this.logger.error("Error importing schools:", error);
+      throw this.handleError(error, "Failed to import schools");
+    } finally {
+      this.isImporting = false;
+    }
+  }
+
+  private handleError(error: unknown, context: string) {
+    if (error instanceof HttpException) {
+      return error;
+    }
+
+    if (error instanceof Error) {
+      return new InternalServerErrorException(`${context}: ${error.message}`);
+    }
+
+    return new InternalServerErrorException(context);
+  }
+
+  private async downloadFile(sourceUrl: string, destinationFilename: string) {
+    this.logger.log(`Downloading ${destinationFilename} from ${sourceUrl}`);
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort();
+    }, this.FETCH_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(sourceUrl, {
+        redirect: "manual",
+        signal: controller.signal,
+      });
+
+      if (response.status >= 300 && response.status < 400) {
+        throw new BadRequestException("Redirects are not allowed");
+      }
+
+      if (!response.ok) {
+        throw new Error(
+          `Failed to download file: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      const contentType = response.headers.get("content-type");
+
+      // Ministry should return application/octet-stream
+      if (contentType !== "application/octet-stream") {
+        throw new BadRequestException(
+          "The selected address did not return a CSV",
+        );
+      }
+
+      const buffer = await response.arrayBuffer();
+
+      const filePath = resolve(this.tmpPath, destinationFilename);
+      await writeFile(filePath, Buffer.from(buffer));
+
+      this.logger.log(`File ${destinationFilename} downloaded successfully`);
+    } catch (error) {
+      // See https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch#exceptions
+      if (error instanceof DOMException && error.name === "AbortError") {
+        throw new BadRequestException(
+          `Download timeout: request took longer than ${this.FETCH_TIMEOUT_MS / 1000} seconds`,
+        );
+      }
+
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private validateUrlPattern(
+    url: string,
+    pattern: RegExp,
+    errorMessage: string,
+  ) {
+    try {
+      new URL(url);
+    } catch {
+      throw new BadRequestException("Invalid URL");
+    }
+
+    if (!pattern.test(url)) {
+      throw new BadRequestException(errorMessage);
+    }
+  }
+}

--- a/packages/server/src/modules/retail-location/retail-location.service.ts
+++ b/packages/server/src/modules/retail-location/retail-location.service.ts
@@ -65,7 +65,7 @@ export class RetailLocationService {
     const filePromises = [];
     const backupDirectory = this.resolveStoragePath(
       locationId,
-      `./backups/${new Date().toISOString()}`,
+      `./backups/${new Date().toISOString().replace(/:/g, "_").replace(/\./g, "_")}`,
     );
     // Ensure the directory exists
     await mkdir(backupDirectory, { recursive: true });


### PR DESCRIPTION
## What it does
This feature implements an admin-only dialog for launching the import of books and schools data from the GUI

## How to test it
- log in as administrator
- click the settings dropdown menu in the drawer
- select "Import books and schools"
- get the URLs to the books data from the ministry website, following the instructions in the dialog
- press the relative button to start the import, and wait until it fiinishes loading
- once it finished loading, verify that an alert with a confirmation message (or error message, in case of error) is shown
- repeat this step for the schools data, making sure to fill both fields before attempting to start the import