### PR TITLE
fix(client): drop heavy fields from operator email suggester query

### DIFF
--- a/packages/client/src/components/add-new-user-dialog.vue
+++ b/packages/client/src/components/add-new-user-dialog.vue
@@ -36,7 +36,7 @@ import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { emailRule, requiredRule } from "src/helpers/rules";
 import { useRetailLocationService } from "src/services/retail-location";
-import { useGetAllCustomersQuery } from "src/services/user.graphql";
+import { useGetAllCustomersEmailsQuery } from "src/services/user.graphql";
 import KDialogFormCard from "./k-dialog-form-card.vue";
 
 defineEmits(useDialogPluginComponent.emitsObject);
@@ -49,7 +49,7 @@ const { t } = useI18n();
 const email = ref("");
 
 const { selectedLocation } = useRetailLocationService();
-const { allUsers: customers } = useGetAllCustomersQuery(() => ({
+const { allUsers: customers } = useGetAllCustomersEmailsQuery(() => ({
   retailLocationId: selectedLocation.value.id,
 }));
 

--- a/packages/client/src/services/user.graphql
+++ b/packages/client/src/services/user.graphql
@@ -77,10 +77,10 @@ query getCustomers(
   }
 }
 
-query getAllCustomers($retailLocationId: String!) {
+query getAllCustomersEmails($retailLocationId: String!) {
   allUsers(retailLocationId: $retailLocationId) {
-    ...Customer
-    ...Member
+    id
+    email
   }
 }
 


### PR DESCRIPTION
The add-operator dialog only needs the list of existing emails, but it
fetched the full Customer+Member fragments, resolving 8 heavy per-user
aggregate fields (books counts, role).
Replace with dedicated getAllCustomersEmails query returning only
id and email.